### PR TITLE
Remote interpreter 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,9 @@
     "rules": {
       "no-console": 0,
       "no-underscore-dangle": 0,
-      "no-return-assign": 0
+      "no-return-assign": 0,
+      "no-extend-native": 0,
+      "prefer-destructuring": 0
     },
-    "extends": "prettier"
+    "extends": ["airbnb-base"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
       "no-underscore-dangle": 0,
       "no-return-assign": 0,
       "no-extend-native": 0,
+      "no-lonely-if": 0,
       "prefer-destructuring": 0
     },
     "extends": ["airbnb-base"]

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "parser": "flow",
+  "semi": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -30,29 +30,40 @@ In addition, the following features are not supported yet:
 * Multi-contract calls
 * Events
 
-## Installation
-Run `npm install`, then `node server.js`.
-Debug mode: `npm run debug`. Debug mode provides greater verbosity about your code that was being sent to the rpc server.
+## Getting Started
+### Installation
+Install the node packages and dependencies: `npm install`
 
-### Compiling Scilla
+Scilla files must be processed using the `scilla-interpreter`. The [Scilla interpreter](https://scilla.readthedocs.io/en/latest/interface.html) executable provides a calling interface that enables users to invoke transitions with specified inputs and obtain outputs. 
 
-`Kaya` uses the scilla interpreter (scilla-runner) to interpret `.scilla` files. As such, you will have to compile the binary yourself from the [scilla repository](https://github.com/Zilliqa/scilla).
+#### Using Remote Scilla Interpreter (Default)
 
-To compile the interpreter:
+By default, Kaya RPC uses the remote scilla interpreter to process `.scilla` files. You do not have to change any configurations.
+
+#### Using Local Scilla Interpreter
+You can choose to use your own scilla interpreter locally. To do it, you will have to compile the binary yourself from the [scilla repository](https://github.com/Zilliqa/scilla) and transfer it to the correct directory within Kaya RPC. 
+
+Instructions: 
 1. Ensure that you have installed the related dependencies: [INSTALL.md](https://github.com/Zilliqa/scilla/blob/master/INSTALL.md)
 2. Then, run `make clean; make`
 3. Copy the `scilla-runner` from `[SCILLA_DIR]/bin` into `[Kaya_DIR]/components/scilla/`
+4. Open `config.js` file and set the `config.scilla.remote` to `false`
 
-## Server Usage
+### Usage
+Kaya RPC two modes: normal and debug. The server listens on port `4200` by default. You can change the port through the `config.js` file.
+- `npm start` : Normal mode
+- `npm run debug`: Enables verbosity mode. Display logs about activities. Useful for debugging
 
-To run the server, do:
-* Normal: `npm start`
-* Normal with debug mode: `npm run debug`
-*
-The server listens on port 4200 by default. You can change the port through the `config.js` file.
+Developers can also start Kaya RPC with accounts from a `fixtures` file. The fixture file is configurable through `config.js`. If you wish to change this file, you will have to follow the format just like `account-fixtures.json`.
+
+To start Kaya RPC with accounts from a file, run one of the following commands:
+- `npm run start:fixtures`: Normal mode
+- `npm run debug:fixtures`: Greater verbosity. Shows log trail about server activities.
+
+__Recommendation__: We recommend running `npm run debug:fixtures`. Without account fixtures, accounts will be randomly generated at every run. It can be time consuming to change the private keys and addresses each time.
 
 ### Advanced: Persistent Storage using Kaya RPC
-By default, the data states are non-persistent. Once you shut down the node server, everything will be deleted.
+By default, the data states are non-persistent. Once you shut down the node server, state files and transactions will be deleted.
 
 To enable persistence data, use:
 ```
@@ -67,7 +78,7 @@ node server.js --load data/save/YYYYMMDDhhmmss_blockchain_states.json
 
 ## Testing
 
-Automated tests are a work-in-progress. For now, you have to run tests manually. 
+Some of the functions in Kaya RPC are covered under automated testing using `jest`. However, scilla related transactions are not covered through automated testing. To test the `CreateTransaction` functionalities, you will have to test it manually.
 
 From `test/scripts/`, you can use run `node DeployContract.js` to test contract deployment. 
 Then, use `node CreateTransaction --key [private-key] --to [contract_addr]` to make transition calls. 
@@ -75,11 +86,13 @@ You can use the `curl` commands stated in the [jsonrpc apidocs](https://apidocs.
 
 Use `--key` to specify a private key. Otherwise, a random privatekey will be generated.
 
-Sample Test Procedure: 
-1. Start the server using `node server.js`
-2. Deploy a contract using `node DeployContract.js --key [private_key]`.
+### Testing with Fixture Files
+
+You can also use the `--test` flag, which uses default test configurations: 
+1. Start the server using `npm run debug:fixtures`
+2. Deploy a contract using `node DeployContract.js --test`.
 3. Check where the contract is deployed. It should be on the logs if you have enabled `debug` mode, otherwise you can check it through the `GetSmartContracts` method.
-4. Send a transaction using `node CreateTransaction.js --key [private_key] --to [Contract_address]`
+4. Send a transaction using `node CreateTransaction.js --test`
 
 ## License
 

--- a/app.js
+++ b/app.js
@@ -37,14 +37,8 @@ expressjs.use(bodyParser.json({ extended: false }));
 let isPersistence = false; // tmp is the default behavior
 
 function makeResponse(id, jsonrpc, data, isErr) {
-  const responseObj = {};
-  responseObj.id = id;
-  responseObj.jsonrpc = jsonrpc;
-  if (isErr) {
-    responseObj.result = { Error: data };
-  } else {
-    responseObj.result = data;
-  }
+  const responseObj = {id, jsonrpc};
+  responseObj.result = isErr ? { Error: data } : data;
   return responseObj;
 }
 
@@ -75,7 +69,6 @@ if (argv.accounts) {
   wallet.loadAccounts(accounts);
 } else {
   /* Create Dummy Accounts */
-  // create 10 wallets by default
   wallet.createWallets(config.wallet.numAccounts);
 }
 wallet.printWallet();

--- a/app.js
+++ b/app.js
@@ -15,224 +15,224 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const express = require('express')
-const bodyParser = require('body-parser')
-const LOG_APPJS = require('debug')('kaya:app.js')
+const express = require('express');
+const bodyParser = require('body-parser');
+const LOG_APPJS = require('debug')('kaya:app.js');
 
-const expressjs = express()
+const expressjs = express();
 
-const fs = require('fs')
-const fsp = require('node-fs')
-const cors = require('cors')
-const { argv } = require('yargs')
-const rimraf = require('rimraf')
-const path = require('path')
+const fs = require('fs');
+const fsp = require('node-fs');
+const cors = require('cors');
+const { argv } = require('yargs');
+const rimraf = require('rimraf');
+const path = require('path');
 
-const config = require('./config')
-const logic = require('./logic')
-const wallet = require('./components/wallet/wallet')
+const config = require('./config');
+const logic = require('./logic');
+const wallet = require('./components/wallet/wallet');
 
-expressjs.use(bodyParser.json({ extended: false }))
+expressjs.use(bodyParser.json({ extended: false }));
 
-let isPersistence = false // tmp is the default behavior
+let isPersistence = false; // tmp is the default behavior
 
 function makeResponse(id, jsonrpc, data, isErr) {
-  const responseObj = {}
-  responseObj.id = id
-  responseObj.jsonrpc = jsonrpc
+  const responseObj = {};
+  responseObj.id = id;
+  responseObj.jsonrpc = jsonrpc;
   if (isErr) {
-    responseObj.result = { Error: data }
+    responseObj.result = { Error: data };
   } else {
-    responseObj.result = data
+    responseObj.result = data;
   }
-  return responseObj
+  return responseObj;
 }
 
 if (argv.save) {
-  LOG_APPJS('Save mode enabled')
-  isPersistence = true
+  LOG_APPJS('Save mode enabled');
+  isPersistence = true;
 }
 
 if (argv.load) {
   // loading option specified
-  LOG_APPJS('Loading option specified.')
-  logic.bootstrapFile(argv.load)
-  isPersistence = true
+  LOG_APPJS('Loading option specified.');
+  logic.bootstrapFile(argv.load);
+  isPersistence = true;
 }
 
 if (process.env.NODE_ENV === 'test') {
-  argv.accounts = 'test/account-fixtures.json'
+  argv.accounts = 'test/account-fixtures.json';
 }
 
 /* account creation/loading based on presets given */
 if (argv.accounts) {
-  LOG_APPJS(`Bootstrapping from account fixture files: ${argv.accounts}`)
-  const accountsPath = argv.accounts
+  LOG_APPJS(`Bootstrapping from account fixture files: ${argv.accounts}`);
+  const accountsPath = argv.accounts;
   if (!fs.existsSync(accountsPath)) {
-    throw new Error('Account Path Invalid')
+    throw new Error('Account Path Invalid');
   }
-  const accounts = JSON.parse(fs.readFileSync(accountsPath, 'utf-8'))
-  wallet.loadAccounts(accounts)
+  const accounts = JSON.parse(fs.readFileSync(accountsPath, 'utf-8'));
+  wallet.loadAccounts(accounts);
 } else {
   /* Create Dummy Accounts */
   // create 10 wallets by default
-  wallet.createWallets(config.wallet.numAccounts)
+  wallet.createWallets(config.wallet.numAccounts);
 }
-wallet.printWallet()
+wallet.printWallet();
 
 // cleanup old folders
 if (fs.existsSync('./tmp')) {
-  LOG_APPJS(`Tmp folder found. Removing ${__dirname}/tmp`)
-  rimraf.sync(path.join(__dirname, '/tmp'))
-  LOG_APPJS(`${__dirname}/tmp removed`)
+  LOG_APPJS(`Tmp folder found. Removing ${__dirname}/tmp`);
+  rimraf.sync(path.join(__dirname, '/tmp'));
+  LOG_APPJS(`${__dirname}/tmp removed`);
 }
 
 if (!fs.existsSync('./tmp')) {
-  fs.mkdirSync('./tmp')
-  LOG_APPJS(`tmp folder created in ${__dirname}/tmp`)
+  fs.mkdirSync('./tmp');
+  LOG_APPJS(`tmp folder created in ${__dirname}/tmp`);
 }
 if (!fs.existsSync('./data')) {
-  fs.mkdirSync('./data')
-  fsp.mkdir('./data/save', 777, true, err => {
+  fs.mkdirSync('./data');
+  fsp.mkdir('./data/save', 777, true, (err) => {
     if (err) {
-      console.log(err)
+      console.log(err);
     } else {
-      LOG_APPJS('Directory created')
+      LOG_APPJS('Directory created');
     }
-  })
+  });
 }
 
 const wrapAsync = fn => (req, res, next) => {
-  Promise.resolve(fn(req, res, next)).catch(next)
-}
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
 
 // cross region settings with Env
 if (process.env.NODE_ENV === 'dev') {
-  expressjs.use(cors())
-  LOG_APPJS('CORS Enabled.')
+  expressjs.use(cors());
+  LOG_APPJS('CORS Enabled.');
 }
 
 expressjs.get('/', (req, res) => {
-  res.status(200).send('Kaya RPC Server')
-})
+  res.status(200).send('Kaya RPC Server');
+});
 
 // Method handling logic for incoming POST request
 
 const handler = async (req, res) => {
-  const { body } = req
-  let data = {}
-  let result
-  let addr
-  LOG_APPJS(`Method specified: ${body.method}`)
+  const { body } = req;
+  let data = {};
+  let result;
+  let addr;
+  LOG_APPJS(`Method specified: ${body.method}`);
   switch (body.method) {
     case 'GetBalance':
       // [addr, ... ] = body.params;
-      addr = body.params[0]
+      addr = body.params[0];
       if (typeof addr === 'object') {
-        addr = JSON.stringify(addr)
+        addr = JSON.stringify(addr);
       }
-      LOG_APPJS(`Getting balance for ${addr}`)
+      LOG_APPJS(`Getting balance for ${addr}`);
 
       try {
-        data = wallet.getBalance(addr)
+        data = wallet.getBalance(addr);
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetNetworkId':
-      data = makeResponse(body.id, body.jsonrpc, 'Testnet', false)
-      res.status(200).send(data)
-      break
+      data = makeResponse(body.id, body.jsonrpc, 'Testnet', false);
+      res.status(200).send(data);
+      break;
     case 'GetSmartContractCode':
       try {
-        result = logic.processGetSmartContractCode(body.params, isPersistence)
-        data = result
+        result = logic.processGetSmartContractCode(body.params, isPersistence);
+        data = result;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetSmartContractState':
       try {
-        result = logic.processGetSmartContractState(body.params, isPersistence)
-        data = result
+        result = logic.processGetSmartContractState(body.params, isPersistence);
+        data = result;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetSmartContractInit':
       try {
-        result = logic.processGetSmartContractInit(body.params, isPersistence)
-        data = result
+        result = logic.processGetSmartContractInit(body.params, isPersistence);
+        data = result;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetSmartContracts':
       try {
-        result = logic.processGetSmartContracts(body.params, argv.save)
-        data = result
+        result = logic.processGetSmartContracts(body.params, argv.save);
+        data = result;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'CreateTransaction':
       try {
-        const txnId = await logic.processCreateTxn(body.params, argv.save)
-        data = txnId
+        const txnId = await logic.processCreateTxn(body.params, argv.save);
+        data = txnId;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetTransaction':
       try {
-        const obj = logic.processGetTransaction(body.params)
-        data = obj
+        const obj = logic.processGetTransaction(body.params);
+        data = obj;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     case 'GetRecentTransactions':
       try {
-        const obj = logic.processGetRecentTransactions()
-        data = obj
+        const obj = logic.processGetRecentTransactions();
+        data = obj;
       } catch (err) {
-        data = err.message
-        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true))
-        break
+        data = err.message;
+        res.status(200).send(makeResponse(body.id, body.jsonrpc, data, true));
+        break;
       }
-      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false))
-      break
+      res.status(200).send(makeResponse(body.id, body.jsonrpc, data, false));
+      break;
     default:
-      data = { Error: 'Unsupported Method' }
-      res.status(404).send(data)
+      data = { Error: 'Unsupported Method' };
+      res.status(404).send(data);
   }
-  LOG_APPJS('Sending status')
-}
+  LOG_APPJS('Sending status');
+};
 
-expressjs.post('/', wrapAsync(handler))
+expressjs.post('/', wrapAsync(handler));
 
 module.exports = {
   expressjs,
   wallet,
-}
+};

--- a/components/blockchain.js
+++ b/components/blockchain.js
@@ -15,16 +15,17 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const config = require('../config')
+const config = require('../config');
 
-let bnum = config.blockchain.blockStart
+let bnum = config.blockchain.blockStart;
+
 function addBnum() {
-  bnum += 1
+  bnum += 1;
 }
 
 // blockinterval is duration for each block number increment
-setInterval(addBnum, config.blockchain.blockInterval)
+setInterval(addBnum, config.blockchain.blockInterval);
 
 module.exports = {
   getBlockNum: () => bnum,
-}
+};

--- a/components/scilla/scilla.js
+++ b/components/scilla/scilla.js
@@ -15,160 +15,140 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const fs = require('fs')
-const LOG_SCILLA = require('debug')('kaya:scilla')
-const { promisify } = require('util')
-const { exec } = require('child_process')
+const fs = require('fs');
+const LOG_SCILLA = require('debug')('kaya:scilla');
+const { promisify } = require('util');
+const { exec } = require('child_process');
 
-const utilities = require('../../utilities')
-const config = require('../../config')
+const utilities = require('../../utilities');
+const config = require('../../config');
 
-const blockchainPath = 'tmp/blockchain.json'
-const colors = require('colors')
+const blockchainPath = 'tmp/blockchain.json';
 
-const execAsync = promisify(exec)
+const execAsync = promisify(exec);
 
-function pad(number, length) {
-  var str = '' + number
-  while (str.length < length) {
-    str = '0' + str
-  }
-  return str
-}
-
-Date.prototype.YYYYMMDDHHMMSS = function() {
-  var yyyy = this.getFullYear().toString()
-  var MM = pad(this.getMonth() + 1, 2)
-  var dd = pad(this.getDate(), 2)
-  var hh = pad(this.getHours(), 2)
-  var mm = pad(this.getMinutes(), 2)
-  var ss = pad(this.getSeconds(), 2)
-
-  return yyyy + MM + dd + hh + mm + ss
-}
-
-const makeBlockchainJson = val => {
+const makeBlockchainJson = (val) => {
   const blockchainData = [
     {
       vname: 'BLOCKNUMBER',
       type: 'BNum',
       value: val.toString(),
     },
-  ]
-  fs.writeFileSync(blockchainPath, JSON.stringify(blockchainData))
-  LOG_SCILLA(`blockchain.json file prepared for blocknumber: ${val}`)
-}
+  ];
+  fs.writeFileSync(blockchainPath, JSON.stringify(blockchainData));
+  LOG_SCILLA(`blockchain.json file prepared for blocknumber: ${val}`);
+};
 
-const initializeContractState = amt => {
+const initializeContractState = (amt) => {
   const initState = [
     {
       vname: '_balance',
       type: 'Uint128',
       value: amt.toString(),
     },
-  ]
-  return initState
-}
+  ];
+  return initState;
+};
 
 const runLocalInterpreterAsync = async (command, outputPath) => {
-  LOG_SCILLA('Running local scilla interpreter (Sync)')
+  LOG_SCILLA('Running local scilla interpreter (Sync)');
   // Run Scilla Interpreter
   if (!fs.existsSync(config.scilla.runner_path)) {
     LOG_SCILLA(
-      'Scilla runner not found. Hint: Have you compiled the scilla binaries?'
-    )
-    throw new Error('Kaya RPC Runtime Error: Scilla-runner not found')
+      'Scilla runner not found. Hint: Have you compiled the scilla binaries?',
+    );
+    throw new Error('Kaya RPC Runtime Error: Scilla-runner not found');
   }
 
-  const result = await execAsync(command)
+  const result = await execAsync(command);
   if (result.stderr !== '') {
-    throw new Error(`Interpreter error: ${result.stderr}`)
+    throw new Error(`Interpreter error: ${result.stderr}`);
   }
 
-  LOG_SCILLA('Scilla execution completed')
+  LOG_SCILLA('Scilla execution completed');
 
-  const retMsg = JSON.parse(fs.readFileSync(outputPath, 'utf-8'))
-  return retMsg
-}
+  const retMsg = JSON.parse(fs.readFileSync(outputPath, 'utf-8'));
+  return retMsg;
+};
 
 module.exports = {
   executeScillaRun: async (payload, address, dir, currentBnum, gasLimit) => {
     // Get the blocknumber into a json file
-    makeBlockchainJson(currentBnum)
+    makeBlockchainJson(currentBnum);
 
-    let isCodeDeployment = payload.code && payload.to === '0'.repeat(40)
-    const contractAddr = isCodeDeployment ? address : payload.to
+    let isCodeDeployment = payload.code && payload.to === '0'.repeat(40);
+    const contractAddr = isCodeDeployment ? address : payload.to;
 
-    const initPath = `${dir}${contractAddr}_init.json`
-    const codePath = `${dir}${contractAddr}_code.scilla`
-    const outputPath = `tmp/${contractAddr}_out.json`
-    const statePath = `${dir}${contractAddr}_state.json`
+    const initPath = `${dir}${contractAddr}_init.json`;
+    const codePath = `${dir}${contractAddr}_code.scilla`;
+    const outputPath = `tmp/${contractAddr}_out.json`;
+    const statePath = `${dir}${contractAddr}_state.json`;
 
     let cmd = `${
       config.scilla.runner_path
-    } -iblockchain ${blockchainPath} -o ${outputPath} -init ${initPath} -i ${codePath} -gaslimit ${gasLimit}`
+    } -iblockchain ${blockchainPath} -o ${outputPath} -init ${initPath} -i ${codePath} -gaslimit ${gasLimit}`;
     console.log(cmd);
 
     if (isCodeDeployment) {
-      LOG_SCILLA('Code Deployment')
+      LOG_SCILLA('Code Deployment');
 
       // initialized with standard message template
-      isCodeDeployment = true
+      isCodeDeployment = true;
 
       // get init data from payload
-      const initParams = JSON.stringify(payload.data)
-      const cleanedParams = utilities.paramsCleanup(initParams)
-      fs.writeFileSync(initPath, cleanedParams)
+      const initParams = JSON.stringify(payload.data);
+      const cleanedParams = utilities.paramsCleanup(initParams);
+      fs.writeFileSync(initPath, cleanedParams);
 
-      const rawCode = JSON.stringify(payload.code)
-      const cleanedCode = utilities.codeCleanup(rawCode)
-      fs.writeFileSync(codePath, cleanedCode)
+      const rawCode = JSON.stringify(payload.code);
+      const cleanedCode = utilities.codeCleanup(rawCode);
+      fs.writeFileSync(codePath, cleanedCode);
     } else {
-      LOG_SCILLA(`Calling transition within contract ${payload.to}`)
+      LOG_SCILLA(`Calling transition within contract ${payload.to}`);
 
-      LOG_SCILLA(`Code Path: ${codePath}`)
-      LOG_SCILLA(`Init Path: ${initPath}`)
+      LOG_SCILLA(`Code Path: ${codePath}`);
+      LOG_SCILLA(`Init Path: ${initPath}`);
       if (!fs.existsSync(codePath) || !fs.existsSync(initPath)) {
         // tocheck what is the expected behavior on jsonrpc
-        LOG_SCILLA('Error, contract has not been created.')
-        throw new Error('Address does not exist')
+        LOG_SCILLA('Error, contract has not been created.');
+        throw new Error('Address does not exist');
       }
 
       // get message from payload information
-      const msgPath = `${dir}${payload.to}_message.json`
-      LOG_SCILLA('Payload Received %O', payload.data)
-      const incomingMessage = JSON.stringify(payload.data)
-      const cleanedMsg = utilities.paramsCleanup(incomingMessage)
-      fs.writeFileSync(msgPath, cleanedMsg)
+      const msgPath = `${dir}${payload.to}_message.json`;
+      LOG_SCILLA('Payload Received %O', payload.data);
+      const incomingMessage = JSON.stringify(payload.data);
+      const cleanedMsg = utilities.paramsCleanup(incomingMessage);
+      fs.writeFileSync(msgPath, cleanedMsg);
 
       // Invoke contract requires additional message and state paths
-      cmd = `${cmd} -imessage ${msgPath} -istate ${statePath}`
+      cmd = `${cmd} -imessage ${msgPath} -istate ${statePath}`;
     }
 
     if (!fs.existsSync(codePath) || !fs.existsSync(initPath)) {
-      LOG_SCILLA('Error, contract has not been created.')
-      throw new Error('Address does not exist')
+      LOG_SCILLA('Error, contract has not been created.');
+      throw new Error('Address does not exist');
     }
 
-    const retMsg = await runLocalInterpreterAsync(cmd, outputPath)
+    const retMsg = await runLocalInterpreterAsync(cmd, outputPath);
 
     // Extract state from tmp/out.json
-    let newState = JSON.stringify(retMsg.states)
+    let newState = JSON.stringify(retMsg.states);
     if (isCodeDeployment) {
-      newState = JSON.stringify(initializeContractState(payload.amount))
+      newState = JSON.stringify(initializeContractState(payload.amount));
     }
 
-    fs.writeFileSync(statePath, newState)
-    LOG_SCILLA(`State logged down in ${statePath}`)
-    console.log(`Contract Address Deployed: ${contractAddr}`)
+    fs.writeFileSync(statePath, newState);
+    LOG_SCILLA(`State logged down in ${statePath}`);
+    console.log(`Contract Address Deployed: ${contractAddr}`);
 
-    responseData = {};
+    const responseData = {};
     responseData.gasRemaining = retMsg.gas_remaining;
 
     // get the error message log
     if (retMsg.message != null) {
-      LOG_SCILLA(`Next address: ${retMsg.message._recipient}`)
-      responseData.nextAddress = retMsg.message._recipient
+      LOG_SCILLA(`Next address: ${retMsg.message._recipient}`);
+      responseData.nextAddress = retMsg.message._recipient;
     }
     // Contract deployment runs do not have returned message
     responseData.nextAddress = '0'.repeat(40);
@@ -176,4 +156,4 @@ module.exports = {
 
     return responseData;
   },
-}
+};

--- a/components/scilla/scilla.js
+++ b/components/scilla/scilla.js
@@ -98,7 +98,7 @@ const runRemoteInterpreterAsync = async (data) => {
 const runLocalInterpreterAsync = async (command, outputPath) => {
   LOG_SCILLA('Running local scilla interpreter');
   // Run Scilla Interpreter
-  if (!fs.existsSync(config.scilla.runner_path)) {
+  if (!fs.existsSync(config.scilla.runnerPath)) {
     LOG_SCILLA(
       'Scilla runner not found. Hint: Have you compiled the scilla binaries?',
     );
@@ -130,8 +130,8 @@ module.exports = {
     const statePath = `${dir}${contractAddr}_state.json`;
 
     let cmd = `${
-      config.scilla.runner_path
-    } -iblockchain ${blockchainPath} -o ${outputPath} -init ${initPath} -i ${codePath} -gaslimit ${gasLimit}`;
+      config.scilla.runnerPath
+    } -iblockchain ${blockchainPath} -o ${outputPath} -init ${initPath} -i ${codePath} -gaslimit ${gasLimit} -libdir ${config.scilla.localLibDir}`;
 
     if (isCodeDeployment) {
       LOG_SCILLA('Code Deployment');

--- a/components/scilla/stdlib/BoolUtils.scilla
+++ b/components/scilla/stdlib/BoolUtils.scilla
@@ -1,0 +1,30 @@
+library BoolUtils
+
+let andb = 
+  fun (b : Bool) =>
+  fun (c : Bool) =>
+    match b with 
+    | False => False
+    | True  =>
+      match c with 
+      | False => False
+      | True  => True
+      end
+    end
+
+let orb = 
+  fun (b : Bool) => fun (c : Bool) =>
+    match b with 
+    | True  => True
+    | False =>
+      match c with 
+      | False => False
+      | True  => True
+      end
+    end
+
+let negb = fun (b : Bool) => 
+  match b with
+  | True => False
+  | False => True
+  end

--- a/components/scilla/stdlib/ListUtils.scilla
+++ b/components/scilla/stdlib/ListUtils.scilla
@@ -1,0 +1,519 @@
+library ListUtils
+
+(* ('A -> 'B) -> List 'A -> List 'B *)
+(* Apply (f : 'A -> 'B) to every element of List 'A *)
+(* to generate List 'B. *)
+let list_map = tfun 'A => tfun 'B =>
+  fun (f : 'A -> 'B) => fun (l : List 'A) =>
+  let folder = @list_foldr 'A (List 'B) in
+  let init = Nil {'B} in
+  let iter = fun (h : 'A) => fun (z : List 'B) =>
+    let h1 = f h in
+    Cons {'B} h1 z  		
+	in folder iter init l
+
+(* ('A -> Bool) -> List 'A -> List 'A *)
+(* Preserving the order of elements in (l : List 'A),  *)
+(* return new list containing only those elements *)
+(* that satisfy the function f. *)
+let list_filter =
+  tfun 'A =>
+  fun (f : 'A -> Bool) =>
+  fun (l : List 'A) =>
+    let folder = @list_foldr 'A (List 'A) in
+    let init = Nil {'A} in
+    let iter =
+      fun (h : 'A) =>
+      fun (z : List 'A) =>
+        let h1 = f h in
+        match h1 with
+        | True =>
+          Cons {'A} h z
+        | False =>
+          z
+        end
+     in
+       folder iter init l
+
+(* (List 'A) -> (Option 'A) *)
+(* Return the head element of a list as Some 'A, None otherwise *)
+let list_head =
+  tfun 'A =>
+  fun (l : List 'A) =>
+    match l with
+    | Cons h t =>
+      Some {'A} h
+    | Nil =>
+      None {'A}
+    end
+
+(* (List 'A) -> (Option List 'A) *)
+(* Return the list except for the head *)
+let list_tail =
+  tfun 'A =>
+  fun (l : List 'A) =>
+    match l with
+    | Cons h t =>
+      Some {(List 'A)} t
+    | Nil =>
+      None {(List 'A)}
+    end
+
+(* (List 'A -> List 'A ->  List 'A) *)
+(* Append the second list to the first one and return a new List *)
+let list_append =
+  tfun 'A =>
+  fun (l1 : List 'A) =>
+  fun (l2 : List 'A) =>
+    (* Fold right over l1 and keep prepending elements to l2 *)
+    (* l2 is the initial accumulator *)
+    let folder = @list_foldr 'A (List 'A) in
+    let init = l2 in
+    let iter =
+      fun (h : 'A) =>
+      fun (z : List 'A) =>
+        Cons {'A} h z
+    in
+      folder iter init l1
+
+(* (List 'A -> List 'A) *)
+(* Return the reverse of the argument list *)
+let list_reverse =
+  tfun 'A =>
+  fun (l : List 'A) =>
+    let folder = @list_foldl 'A (List 'A) in
+    let init = Nil {'A} in
+    let iter =
+      fun (z : List 'A) =>
+      fun (h : 'A) =>
+        Cons {'A} h z
+    in
+      folder iter init l
+
+(* (List List 'A) -> List 'A *)
+(* Concatenate a list of lists. The elements of the argument are all *)
+(* concatenated together (in the same order) to give the result. *)
+let list_flatten =
+  tfun 'A =>
+  fun (l : List (List 'A)) =>
+    let folder = @list_foldr (List 'A) (List 'A) in
+    let init = Nil {'A} in
+    let iter =
+      fun (h : List 'A) =>
+      fun (z : List 'A) =>
+        let app = @list_append 'A in
+        app h z
+    in
+      folder iter init l
+
+(* List 'A -> Int32 *)
+(* Number of elements in list *)
+let list_length =
+  tfun 'A =>
+  fun (l : List 'A) =>
+    let folder = @list_foldr 'A Int32 in
+    let init = Int32 0 in
+    let iter =
+      fun (h : 'A) =>
+      fun (z : Int32) =>
+        let one = Int32 1 in
+          builtin add one z
+     in
+       folder iter init l
+
+(* Helper function for list_eq. Not for public use. *)
+(* Returns Some Nil on successul match. None otherwise. *)
+let list_eq_helper =
+  tfun 'A =>
+  fun (eq : 'A -> 'A -> Bool) =>
+  fun (l1 : List 'A) =>
+  fun (l2 : List 'A) =>
+    let folder = @list_foldl 'A (Option (List 'A)) in
+    let init = Some {(List 'A)} l2 in
+    let iter =
+      fun (z : Option (List 'A)) =>
+      fun (h1 : 'A) =>
+        match z with
+        | Some ll2 =>
+          let headF = @list_head 'A in
+          let h2o = headF ll2 in
+          match h2o with
+          | Some h2 =>
+            let eqb = eq h1 h2 in
+            match eqb with
+            | True =>
+              let tailF = @list_tail 'A in
+              tailF ll2
+            | False =>
+              None {(List 'A)}
+            end
+          | None =>
+            None {(List 'A)}
+          end
+        | None =>
+          None {(List 'A)}
+        end
+    in
+      folder iter init l1
+
+(* ('A -> 'A -> Bool) -> List 'A -> List 'A -> Bool *)
+(* Return true iff two lists compare equal. *)
+(* Comparison is performed using the "f" function provided. *)
+let list_eq =
+  tfun 'A =>
+  fun (f : 'A -> 'A -> Bool) =>
+  fun (l1 : List 'A) =>
+  fun (l2 : List 'A) =>
+    let eqh = @list_eq_helper 'A in
+    let res = eqh f l1 l2 in
+    match res with
+    | Some l =>
+      match l with
+      | Nil =>
+        True
+      | _ =>
+        False
+      end
+    | _ =>
+      False
+    end
+
+(* ('A -> 'A -> Bool) -> 'A -> List 'A -> Bool *)
+(* Return True iff "m" is in the list "l", as compared by function "f". *)
+let list_mem =
+  tfun 'A =>
+  fun (f : 'A -> 'A -> Bool) =>
+  fun (m : 'A) =>
+  fun (l : List 'A) =>
+    let folder = @list_foldl 'A Bool in
+    let init = False in
+    let iter =
+      fun (z : Bool) =>
+      fun (h : 'A) =>
+        let res = f h m in
+        match res with
+        | True =>
+          True
+        | False =>
+          z
+        end
+    in
+      folder iter init l
+
+(* ('A -> Bool) -> List 'A -> Bool *)
+(* Return True iff all elements of list "l" satisfy predicate "f". *)
+let list_forall =
+  tfun 'A =>
+  fun (f : 'A -> Bool) =>
+  fun (l : List 'A) =>
+    let folder = @list_foldl 'A Bool in
+    let init = True in
+    let iter =
+      fun (z : Bool) =>
+      fun (h : 'A) =>
+        let res = f h in
+        match res with
+        | False =>
+          False
+        | True =>
+          z
+        end
+    in
+    folder iter init l
+
+(* ('A -> Bool) -> List 'A -> Bool *)
+(* Return True iff at least one element of list "l" satisfy predicate "f". *)
+let list_exists =
+  tfun 'A =>
+  fun (f : 'A -> Bool) =>
+  fun (l : List 'A) =>
+    let folder = @list_foldl 'A Bool in
+    let init = False in
+    let iter =
+      fun (z : Bool) =>
+      fun (h : 'A) =>
+        let res = f h in
+        match res with
+        | True =>
+          True
+        | False =>
+          z
+        end
+    in
+      folder iter init l
+
+(* ('A -> 'A -> Bool) -> List 'A -> List 'A *)
+(* Stable sort the input list "l". *)
+(* "flt" returns True if the first argument is lesser-than the second *)
+let list_sort =
+  (* Insertion sort *)
+  tfun 'A =>
+  fun (flt : 'A -> 'A -> Bool) =>
+  fun (ls : List 'A) =>
+    let true = True in 
+    let false = False in
+    let rec_A_A = @list_foldr 'A (List 'A) in
+    let rec_A_Pair = @list_foldr 'A (Pair Bool (List 'A))  in
+    let nil_A = Nil {'A} in 
+    let sink_down =
+      fun (e : 'A) => fun (ls : List 'A) =>
+        let init = Pair {Bool (List 'A)} false nil_A in
+        let iter1 =
+          fun (h : 'A) =>
+          fun (res : Pair Bool (List 'A)) =>
+            match res with
+            | Pair True rest =>
+              let z = Cons {'A} h rest in
+              Pair {Bool (List 'A)} true z
+            | Pair False rest =>
+              let bl = flt h e in
+              match bl with
+              | True =>
+                let z = Cons {'A} e rest in
+                let z2 = Cons {'A} h z in
+                Pair {Bool (List 'A)} true z2
+              | False =>
+                let z = Cons {'A} h rest in
+                Pair {Bool (List 'A)} false z
+              end
+            end   
+        in
+        let res1 = rec_A_Pair iter1 init ls in
+        match res1 with
+        | Pair True ls1 => ls1
+        | Pair False ls1 => Cons {'A} e ls1
+        end
+    in
+    let iter2 =
+      fun (h : 'A) =>
+      fun (res : List 'A) =>
+        sink_down h res
+    in 
+      rec_A_A iter2 nil_A ls
+
+
+(* ('A -> Bool) -> 'A -> 'A *)
+(* Return Some a, where "a" is the first element of *)
+(* "l" that satisfies the predicate "f". *)
+(* Return None iff none of the elements in "l" satisfy "f". *)
+let list_find =
+  tfun 'A =>
+  fun (f : 'A -> Bool) =>
+  fun (l : List 'A) =>
+    let folder = @list_foldl 'A (Option 'A) in
+    let init = None {'A} in
+    let iter =
+      fun (z : Option 'A) =>
+      fun (h : 'A) =>
+        match z with
+        | Some a =>
+          z
+        | None =>
+          let r = f h in
+          match r with
+          | True =>
+            Some {'A} h
+          | False =>
+            None {'A}
+          end
+        end
+     in
+       folder iter init l
+
+(* List 'A -> List 'B -> List (Pair 'A 'B) *)
+(* Combine corresponding elements of m1 and m2 into a pair *)
+(* and return the resulting list. In case of different number *)
+(* of elements in the lists, the extra elements are ignored. *)
+let list_zip =
+  tfun 'A =>
+  tfun 'B =>
+  fun (m1 : List 'A) =>
+  fun (m2 : List 'B) =>
+    let list_zip_helper =
+      tfun 'A =>
+      tfun 'B =>
+      fun (l1 : List 'A) =>
+      fun (l2 : List 'B) =>
+        let folder = @list_foldl 'A (Pair (List (Pair 'A 'B)) (List 'B)) in
+        let nil = Nil {(Pair 'A 'B)} in
+        let init = Pair {(List (Pair 'A 'B)) (List 'B)} nil l2 in
+        let iter =
+          fun (z : Pair (List (Pair 'A 'B)) (List 'B)) =>
+          fun (h : 'A) =>
+            match z with
+            | Pair r b =>
+              (* Get b's head, pair it with h and add to r. *)
+              let header = @list_head 'B in
+              let tailer = @list_tail 'B in
+              let bhead = header b in
+              match bhead with
+              | Some bel =>
+                let newp = Pair {'A 'B} h bel in
+                let newp_concat = Cons {(Pair 'A 'B)} newp r in
+                let btail = tailer b in
+                let newb =
+                  match btail with
+                  | Some t =>
+                    t
+                  | None =>
+                    let nilb = Nil {'B} in
+                    nilb
+                  end
+                in
+                Pair {(List (Pair 'A 'B)) (List 'B)} newp_concat newb
+              | None =>
+                z
+              end
+            end
+          in
+            folder iter init l1
+    in
+      let zipper = @list_zip_helper 'A 'B in
+      let res = zipper m1 m2 in
+      match res with
+      | Pair x y =>
+        let reverser = @list_reverse (Pair 'A 'B) in
+          reverser x
+      end
+
+(* ('A -> 'B -> 'C) -> List 'A -> List 'B -> List 'C *)
+(* Combine corresponding elements of m1 and m2 using "f" *)
+(* and return the resulting list of 'C. In case of different number *)
+(* of elements in the lists, the extra elements are ignored. *)
+let list_zip_with =
+  tfun 'A =>
+  tfun 'B =>
+  tfun 'C =>
+  fun (f : 'A -> 'B -> 'C) =>
+  fun (m1 : List 'A) =>
+  fun (m2 : List 'B) =>
+    let list_zip_helper =
+      tfun 'A =>
+      tfun 'B =>
+      tfun 'C =>
+      fun (g : 'A -> 'B -> 'C) =>
+      fun (l1 : List 'A) =>
+      fun (l2 : List 'B) =>
+        let folder = @list_foldl 'A (Pair (List 'C) (List 'B)) in
+        let nilb = Nil {'B} in
+        let nilc = Nil {'C} in
+        let init = Pair {(List 'C) (List 'B)} nilc l2 in
+        let iter =
+          fun (z : Pair (List 'C) (List 'B)) =>
+          fun (h : 'A) =>
+            match z with
+            | Pair r b =>
+              (* Get b's head, pair it with h and add to r. *)
+              let header = @list_head 'B in
+              let tailer = @list_tail 'B in
+              let bhead = header b in
+              match bhead with
+              | Some bel =>
+                let newp = g h bel in
+                let newp_concat = Cons {'C} newp r in
+                let btail = tailer b in
+                let newb =
+                  match btail with
+                  | Some t =>
+                    t
+                  | None =>
+                    nilb
+                  end
+                in
+                Pair {(List 'C) (List 'B)} newp_concat newb
+              | None =>
+                z
+              end
+            end
+          in
+            folder iter init l1
+    in
+      let zipper = @list_zip_helper 'A 'B 'C in
+      let res = zipper f m1 m2 in
+      match res with
+      | Pair x y =>
+        let reverser = @list_reverse 'C in
+          reverser x
+      end
+
+(* List (Pair 'A 'B) -> Pair (List 'A) (List 'B) *)
+let list_unzip =
+  tfun 'A =>
+  tfun 'B =>
+  fun (l : List (Pair 'A 'B)) =>
+    let folder = @list_foldr (Pair 'A 'B) (Pair (List 'A) (List 'B)) in
+    let nil1 = Nil {'A} in
+    let nil2 = Nil {'B} in
+    let init = Pair {(List 'A) (List 'B)} nil1 nil2 in
+    let iter =
+      fun (h : Pair 'A 'B) =>
+      fun (z : Pair (List 'A) (List 'B)) =>
+        match h with
+        | Pair a b =>
+          match z with
+          | Pair la lb =>
+            let nla = Cons {'A} a la in
+            let nlb = Cons {'B} b lb in
+            Pair {(List 'A)(List 'B)} nla nlb
+          end
+        end
+    in
+      folder iter init l
+
+(* List (Pair 'A 'B) -> Map 'A 'B *)
+(* Convert a list of key-val pairs into a map, overwriting duplicates. *)
+let list_to_map =
+  tfun 'A =>
+  tfun 'B =>
+  fun (l : List (Pair 'A 'B)) =>
+    let folder = @list_foldl (Pair 'A 'B) (Map 'A 'B) in
+    let init = Emp 'A 'B in
+    let iter =
+      fun (z : Map 'A 'B) =>
+      fun (h : Pair 'A 'B) =>
+        match h with
+        | Pair a b =>
+          builtin put z a b
+        end
+    in
+      folder iter init l
+
+(* Int32 -> List 'A -> Option 'A *)
+(* Returns (Some 'A) if n'th element exists in list. None otherwise *)
+let list_nth =
+  tfun 'A =>
+  fun (n_h : Int32) =>
+  fun (l_h : List 'A) =>
+    let list_nth_helper =
+      tfun 'A =>
+      fun (n : Int32) =>
+      fun (l : List 'A) =>
+        let folder = @list_foldl 'A (Pair Int32 (Option 'A)) in
+        let zero = Int32 0 in
+        let none = None {'A} in
+        let init = Pair {Int32 (Option 'A)} zero none in
+        let iter =
+          fun (z : Pair Int32 (Option 'A)) =>
+          fun (h : 'A) =>
+            match z with
+            | Pair i oe =>
+              let one = Int32 1 in
+              let nexti = builtin add i one in
+              let this = builtin eq n i in
+              match this with
+              | True =>
+                let someh = Some {'A} h in
+                Pair {Int32 (Option 'A)} nexti someh
+              | False =>
+                Pair {Int32 (Option 'A)} nexti oe
+              end
+            end
+          in
+          folder iter init l
+    in
+    let nth = @list_nth_helper 'A in
+    let res = nth n_h l_h in
+    match res with
+    | Pair i oe =>
+      oe
+    end

--- a/components/scilla/stdlib/NatUtils.scilla
+++ b/components/scilla/stdlib/NatUtils.scilla
@@ -1,0 +1,87 @@
+library NatUtils
+
+(* Nat -> Option Nat *)
+let nat_prev = fun (n: Nat) =>
+  match n with
+	| Succ n1 => Some {Nat} n1
+	| Zero => None {Nat}
+	end
+
+(* Nat -> Bool *)
+let is_some_zero = fun (n: Nat) =>
+	match n with
+  | Zero => True
+  | _ => False
+	end
+
+(* Nat -> Nat -> Bool *)
+let nat_eq = fun (n : Nat) => fun (m : Nat) =>
+  let z = Some {Nat} m in
+		let f = fun (res : Option Nat) => fun (n : Nat) =>
+      match res with
+      | None => None {Nat}
+      | Some m1 => nat_prev m1
+			end in
+	let folder = @nat_fold (Option Nat) in
+  let e = folder f z n in
+  match e with
+  | Some Zero => True
+  | _ => False
+	end
+
+(* Nat -> Uint32 *)
+let nat_to_int =
+  fun (n : Nat) =>
+    let f =
+      fun (z : Uint32) =>
+      fun (n : Nat) =>
+        match n with
+        | _ =>
+          let one_int = Uint32 1 in
+          builtin add z one_int
+        end
+    in
+    let folder = @nat_fold Uint32 in
+    let zero_int = Uint32 0 in
+      folder f zero_int n
+
+let uint32_to_nat_helper =
+  fun (m : Option Uint32) =>
+    match m with
+    | Some x =>
+      let res = builtin to_nat x in
+      Some {Nat} res
+    | None => None {Nat}
+    end
+
+(* UintX/IntX -> Option Nat *)
+let uint32_to_nat =
+  fun (n : Uint32) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+
+let uint64_to_nat =
+  fun (n : Uint64) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+
+let uint128_to_nat =
+  fun (n : Uint128) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+
+let int32_to_nat =
+  fun (n : Int32) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+
+let int64_to_nat =
+  fun (n : Int64) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+
+let int128_to_nat =
+  fun (n : Int128) =>
+    let m = builtin to_uint32 n in
+    uint32_to_nat_helper m
+

--- a/components/scilla/stdlib/PairUtils.scilla
+++ b/components/scilla/stdlib/PairUtils.scilla
@@ -1,0 +1,17 @@
+library PairUtils
+
+let fst =
+  tfun 'A =>
+  tfun 'B =>
+  fun (p : Pair ('A) ('B)) =>
+    match p with
+    | Pair a b => a
+    end
+
+let snd =
+  tfun 'A =>
+  tfun 'B =>
+  fun (p : Pair ('A) ('B)) =>
+    match p with
+    | Pair a b => b
+    end

--- a/components/wallet/wallet.js
+++ b/components/wallet/wallet.js
@@ -44,9 +44,8 @@ const consolePrint = (text) => {
 const createNewWallet = () => {
   const pk = zilliqa.util.generatePrivateKey();
   const address = zilliqa.util.getAddressFromPrivateKey(pk);
-  const pkString = pk.toString('hex');
   const newWallet = {
-    privateKey: pkString,
+    privateKey: pk,
     amount: config.wallet.defaultAmt,
     nonce: config.wallet.defaultNonce,
   };

--- a/config.js
+++ b/config.js
@@ -40,6 +40,7 @@ config.wallet = {
 config.scilla = {
   runner_path: './components/scilla/scilla-runner',
   mode: 'local', // may include remote mode next time
+  url: 'https://api.zilliqa.com/v1/runner',
 };
 
 config.testconfigs = {

--- a/config.js
+++ b/config.js
@@ -18,32 +18,32 @@
 /* Configuration file */
 /* Feel free to add more things to this file that will help you in development */
 
-const config = module.exports
+const config = module.exports;
 
-config.port = 4200
-config.version = '0.0.1'
+config.port = 4200;
+config.version = '0.0.1';
 
 // blockchain specific configuration
 config.blockchain = {
   // sets timer for the block confirmation
   blockInterval: 10000, // 10000 = 10 seconds for one block
   blockStart: 0,
-  gasPrice: 1 // ratio of gas to zil (dummy value of 1:1)
-}
+  gasPrice: 1, // ratio of gas to zil (dummy value of 1:1)
+};
 
 config.wallet = {
   numAccounts: 10, // number of default accounts
   defaultAmt: 100000, // default amount of zils assigned to each wallet
   defaultNonce: 0,
-}
+};
 
 config.scilla = {
   runner_path: './components/scilla/scilla-runner',
   mode: 'local', // may include remote mode next time
-}
+};
 
 config.testconfigs = {
   gasPrice: 1,
   gasLimit: 10,
   transferAmt: 100,
-}
+};

--- a/config.js
+++ b/config.js
@@ -37,10 +37,16 @@ config.wallet = {
   defaultNonce: 0,
 };
 
+/*
+  Settings for the scilla interpreter
+  - runner-path: Relative path to your scilla-runner
+  - remote: Use the remote scilla interpreter. (Default: True). False: Use local scilla interpreter
+  - url: URL to the remote scilla interpreter
+*/
 config.scilla = {
   runner_path: './components/scilla/scilla-runner',
-  mode: 'local', // may include remote mode next time
-  url: 'https://api.zilliqa.com/v1/runner',
+  remote: true,
+  url: '', // To be filled with actual interpreter server
 };
 
 config.testconfigs = {

--- a/config.js
+++ b/config.js
@@ -1,57 +1,57 @@
 /*
- This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+This file is part of kaya.
+Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
 
-  kaya is free software: you can redistribute it and/or modify it under the
-  terms of the GNU General Public License as published by the Free Software
-  Foundation, either version 3 of the License, or (at your option) any later
-  version.
+kaya is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
 
-  kaya is distributed in the hope that it will be useful, but WITHOUT ANY
-  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+kaya is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License along with
-  kaya.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License along with
+kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 /* Configuration file */
 /* Feel free to add more things to this file that will help you in development */
 
-const config = module.exports;
+module.exports = {
+  port: 4200,
+  version: "0.2.0",
 
-config.port = 4200;
-config.version = '0.2.0';
+  // blockchain specific configuration
+  blockchain: {
+    // sets timer for the block confirmation
+    blockInterval: 10000, // 10000 : 10 seconds for one block
+    blockStart: 0,
+    gasPrice: 1, // ratio of gas to zil (dummy value of 1:1)
+  },
 
-// blockchain specific configuration
-config.blockchain = {
-  // sets timer for the block confirmation
-  blockInterval: 10000, // 10000 = 10 seconds for one block
-  blockStart: 0,
-  gasPrice: 1, // ratio of gas to zil (dummy value of 1:1)
-};
+  wallet: {
+    numAccounts: 10, // number of default accounts
+    defaultAmt: 100000, // default amount of zils assigned to each wallet
+    defaultNonce: 0,
+  },
 
-config.wallet = {
-  numAccounts: 10, // number of default accounts
-  defaultAmt: 100000, // default amount of zils assigned to each wallet
-  defaultNonce: 0,
-};
-
-/*
-  Settings for the scilla interpreter
-  - runner-path: Relative path to your scilla-runner
-  - remote: Use the remote scilla interpreter. (Default: True). False: Use local scilla interpreter
-  - url: URL to the remote scilla interpreter
+  /*
+Settings for the scilla interpreter
+- runner-path: Relative path to your scilla-runner
+- remote: Use the remote scilla interpreter. (Default: True). False: Use local scilla interpreter
+- url: URL to the remote scilla interpreter
 */
-config.scilla = {
-  runnerPath: './components/scilla/scilla-runner',
-  localLibDir: './components/scilla/stdlib',
-  remote: true,
-  url: 'https://scilla-runner.zilliqa.com/contract/call',
-};
+  scilla: {
+    runnerPath: "./components/scilla/scilla-runner",
+    localLibDir: "./components/scilla/stdlib",
+    remote: true,
+    url: "https://scilla-runner.zilliqa.com/contract/call",
+  },
 
-config.testconfigs = {
-  gasPrice: 1,
-  gasLimit: 10,
-  transferAmt: 100,
+  testconfigs: {
+    gasPrice: 1,
+    gasLimit: 10,
+    transferAmt: 100,
+  },
 };

--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@
 const config = module.exports;
 
 config.port = 4200;
-config.version = '0.0.1';
+config.version = '0.2.0';
 
 // blockchain specific configuration
 config.blockchain = {
@@ -46,8 +46,8 @@ config.wallet = {
 config.scilla = {
   runnerPath: './components/scilla/scilla-runner',
   localLibDir: './components/scilla/stdlib',
-  remote: false,
-  url: '', // Intentionally omitted. To be added with actual server API
+  remote: true,
+  url: 'https://scilla-runner.zilliqa.com/contract/call',
 };
 
 config.testconfigs = {

--- a/config.js
+++ b/config.js
@@ -44,9 +44,10 @@ config.wallet = {
   - url: URL to the remote scilla interpreter
 */
 config.scilla = {
-  runner_path: './components/scilla/scilla-runner',
-  remote: true,
-  url: '', // To be filled with actual interpreter server
+  runnerPath: './components/scilla/scilla-runner',
+  localLibDir: './components/scilla/stdlib',
+  remote: false,
+  url: '', // Intentionally omitted. To be added with actual server API
 };
 
 config.testconfigs = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,5 +34,5 @@ const config = {
   //         "statements": 80
   //     }
   // }
-}
-module.exports = config
+};
+module.exports = config;

--- a/logic.js
+++ b/logic.js
@@ -16,12 +16,10 @@
 */
 
 // logic.js : Logic Script
-const hashjs = require('hash.js')
-const fs = require('fs')
-const {
-  Zilliqa
-} = require('zilliqa-js')
-const LOG_LOGIC = require('debug')('kaya:logic')
+const hashjs = require('hash.js');
+const fs = require('fs');
+const { Zilliqa } = require('zilliqa-js');
+const LOG_LOGIC = require('debug')('kaya:logic');
 
 const scillaCtrl = require('./components/scilla/scilla');
 const walletCtrl = require('./components/wallet/wallet');
@@ -29,76 +27,69 @@ const blockchain = require('./components/blockchain');
 const config = require('./config');
 
 // non-persistent states. Initializes whenever server starts
-const transactions = {}
-const createdContractsByUsers = {} // address => contract addresses
+let transactions = {};
+const createdContractsByUsers = {}; // address => contract addresses
 
 /*  Dummy constructor for zilliqajs */
 // @dev: Will be replaced once zilliqa-js exposes utils without constructors
 const zilliqa = new Zilliqa({
   nodeUrl: 'http://localhost:8888',
-})
+});
 
 /* Utility functions */
 
 function pad(number, length) {
-  let str = '' + number
+  let str = number.toString();
   while (str.length < length) {
-    str = '0' + str
+    str = `0${str}`;
   }
-  return str
+  return str;
 }
 
-Date.prototype.YYYYMMDDHHMMSS = function () {
-  var yyyy = this.getFullYear().toString()
-  var MM = pad(this.getMonth() + 1, 2)
-  var dd = pad(this.getDate(), 2)
-  var hh = pad(this.getHours(), 2)
-  var mm = pad(this.getMinutes(), 2)
-  var ss = pad(this.getSeconds(), 2)
-  return yyyy + MM + dd + hh + mm + ss
+Date.prototype.YYYYMMDDHHMMSS = () => {
+  const yyyy = this.getFullYear().toString();
+  const MM = pad(this.getMonth() + 1, 2);
+  const dd = pad(this.getDate(), 2);
+  const hh = pad(this.getHours(), 2);
+  const mm = pad(this.getMinutes(), 2);
+  const ss = pad(this.getSeconds(), 2);
+  return yyyy + MM + dd + hh + mm + ss;
 };
-
 
 // check multiplication overflow: Returns true if overflow
 const checkOverflow = (a, b) => {
   const c = a * b;
   return a !== c / b || b !== c / a;
-}
+};
 
 // compute contract address from the sender's current nonce
-const computeContractAddr = sender => {
-  const userNonce = walletCtrl.getBalance(sender).nonce
-  const nonceStr = zilliqa.util.intToByteArray(userNonce, 64).join('')
-  const digest = hashjs
-    .sha256()
-    .update(sender)
-    .update(nonceStr)
-    .digest('hex')
-  return digest.slice(24)
-}
+const computeContractAddr = (sender) => {
+  const userNonce = walletCtrl.getBalance(sender).nonce;
+  const nonceStr = zilliqa.util.intToByteArray(userNonce, 64).join('');
+  const digest = hashjs.sha256().update(sender).update(nonceStr).digest('hex');
+  return digest.slice(24);
+};
 
 // compute transactionHash from the payload
-const computeTransactionHash = payload => {
+const computeTransactionHash = (payload) => {
   // transactionID is a sha256 digest of txndetails
-  const copyPayload = JSON.parse(JSON.stringify(payload))
-  delete copyPayload.signature // txn hash does not include signature
-  const buf = Buffer.from(JSON.stringify(copyPayload))
+  const copyPayload = JSON.parse(JSON.stringify(payload));
+  delete copyPayload.signature; // txn hash does not include signature
+  const buf = Buffer.from(JSON.stringify(copyPayload));
   const transactionHash = hashjs
     .sha256()
     .update(buf)
-    .digest('hex')
-  return transactionHash
-}
+    .digest('hex');
+  return transactionHash;
+};
 
 // check for common elements within the list
-const intersect = (a, b) => {
-  return [...new Set(a)].filter(x => new Set(b).has(x))
-}
+const intersect = (a, b) => [...new Set(a)].filter(x => new Set(b).has(x));
 
 // checks if the transactionJson is well-formed
-const checkTransactionJson = data => {
-  if (data !== null && typeof data !== 'object') return false
-  const payload = data[0]
+const checkTransactionJson = (data) => {
+  if (data !== null && typeof data !== 'object') return false;
+  const payload = data[0];
   const expectedFields = [
     'version',
     'nonce',
@@ -108,301 +99,308 @@ const checkTransactionJson = data => {
     'gasPrice',
     'gasLimit',
     'signature',
-  ]
+  ];
 
   /* Checking the keys in the payload */
-  const numKeys = Object.keys(payload).length
-  if (numKeys < 8) return false
-  const payloadKeys = Object.keys(payload)
-  const expected = intersect(payloadKeys, expectedFields).length
-  const actual = Object.keys(expectedFields).length
+  const numKeys = Object.keys(payload).length;
+  if (numKeys < 8) return false;
+  const payloadKeys = Object.keys(payload);
+  const expected = intersect(payloadKeys, expectedFields).length;
+  const actual = Object.keys(expectedFields).length;
   // number of overlap keys must be the same as the expected keys
-  if (expected !== actual) return false
+  if (expected !== actual) return false;
   // validate signature - TODO
 
-  return true
-}
+  return true;
+};
 
 module.exports = {
   processCreateTxn: async (data, saveMode) => {
-      LOG_LOGIC('Processing transaction...')
-      // todo: check for well-formness of the payload data
-      LOG_LOGIC(`Payload well-formed? ${checkTransactionJson(data)}`)
-      if (!checkTransactionJson(data)) {
-        throw new Error('Invalid Tx Json');
-      }
+    LOG_LOGIC('Processing transaction...');
+    // todo: check for well-formness of the payload data
+    LOG_LOGIC(`Payload well-formed? ${checkTransactionJson(data)}`);
+    if (!checkTransactionJson(data)) {
+      throw new Error('Invalid Tx Json');
+    }
 
-      const currentBNum = blockchain.getBlockNum()
-      let dir = 'tmp/'
-      if (saveMode) {
-        console.log('Save mode enabled.');
-        dir = 'data/'
-      }
+    const currentBNum = blockchain.getBlockNum();
+    let dir = 'tmp/';
+    if (saveMode) {
+      console.log('Save mode enabled.');
+      dir = 'data/';
+    }
 
-      const payload = data[0];
-      const senderAddress = zilliqa.util.getAddressFromPublicKey(payload.pubKey);
+    const payload = data[0];
+    const senderAddress = zilliqa.util.getAddressFromPublicKey(payload.pubKey);
 
-      LOG_LOGIC(`Sender: ${senderAddress}`);
-      const userNonce = walletCtrl.getBalance(senderAddress).nonce;
-      LOG_LOGIC(`User Nonce: ${userNonce}`);
-      LOG_LOGIC(`Payload Nonce: ${payload.nonce}`);
+    LOG_LOGIC(`Sender: ${senderAddress}`);
+    const userNonce = walletCtrl.getBalance(senderAddress).nonce;
+    LOG_LOGIC(`User Nonce: ${userNonce}`);
+    LOG_LOGIC(`Payload Nonce: ${payload.nonce}`);
 
-      // check if payload gasPrice is sufficient
-      const blockchainGasPrice = config.blockchain.gasPrice;
-      if(payload.gasPrice < blockchainGasPrice) {
-        throw new Error(`Payload gas price is insufficient. Current gas price is ${config.blockchain.gasPrice}`);
-      }
+    // check if payload gasPrice is sufficient
+    const blockchainGasPrice = config.blockchain.gasPrice;
+    if (payload.gasPrice < blockchainGasPrice) {
+      throw new Error(
+        `Payload gas price is insufficient. Current gas price is ${
+          config.blockchain.gasPrice
+        }`,
+      );
+    }
 
-      // check if the payload.nonce is valid
-      if (payload.nonce === userNonce + 1) {
-        // p2p token transfer
-        if (!payload.code && !payload.data) {
-          LOG_LOGIC('p2p token tranfer')
-          walletCtrl.deductFunds(senderAddress, payload.amount + payload.gasLimit)
-          walletCtrl.increaseNonce(senderAddress)
-          walletCtrl.addFunds(payload.to, payload.amount)
-        } else {
-          /* contract generation */
-          LOG_LOGIC('Task: Contract Deployment / Create Transaction')
-          // take the sha256 hash of address+nonce, then extract the rightmost 20 bytes
-          const contractAddr = computeContractAddr(senderAddress);
-
-          if (checkOverflow(payload.gasLimit, payload.gasPrice)) {
-            throw new Error('Overflow detected: Invalid gas limit or gas price');
-          }
-          const gasLimitToZil = payload.gasLimit * payload.gasPrice;
-          const gasAndAmount = payload.amount + gasLimitToZil;
-
-          if (!walletCtrl.sufficientFunds(senderAddress, gasAndAmount)) {
-            LOG_LOGIC('Insufficient funds. Returning error to client.')
-            throw new Error('Insufficient funds')
-          }
-          LOG_LOGIC(`Contract will be deployed at: ${contractAddr}`)
-
-          const responseData = await scillaCtrl.executeScillaRun(
-            payload,
-            contractAddr,
-            dir,
-            currentBNum,
-            payload.gasLimit
-          )
-          // Deduct funds
-          let nextAddr = responseData.nextAddress;
-          let gasConsumed = payload.gasLimit - responseData.gasRemaining;
-          if (checkOverflow(gasConsumed, payload.gasPrice)) {
-            throw new Error('Overflow detected: Invalid gas limit or gas price');
-          }
-          const gasConsumedInZil = gasConsumed * payload.gasPrice;
-
-          walletCtrl.deductFunds(senderAddress, payload.amount + gasConsumedInZil);
-          walletCtrl.increaseNonce(senderAddress) // only increase if a contract is successful
-
-          if (
-            nextAddr !== '0'.repeat(40) &&
-            nextAddr.substring(2) != senderAddress
-          ) {
-            console.log('Multi-contract calls not supported.')
-            throw new Error('Multi-contract calls are not supported yet.')
-          }
-
-          // Only update if it is a deployment call
-          if (payload.code && payload.to === '0'.repeat(40)) {
-            // Update address_to_contracts
-            if (senderAddress in createdContractsByUsers) {
-              LOG_LOGIC('User has contracts. Appending to list')
-              createdContractsByUsers[senderAddress].push(contractAddr)
-            } else {
-              LOG_LOGIC('No existing contracts. Creating new entry.')
-              createdContractsByUsers[senderAddress] = [contractAddr]
-            }
-            LOG_LOGIC('Addr-to-Contracts: %O', createdContractsByUsers)
-          }
-        }
+    // check if the payload.nonce is valid
+    if (payload.nonce === userNonce + 1) {
+      // p2p token transfer
+      if (!payload.code && !payload.data) {
+        LOG_LOGIC('p2p token tranfer');
+        walletCtrl.deductFunds(
+          senderAddress,
+          payload.amount + payload.gasLimit,
+        );
+        walletCtrl.increaseNonce(senderAddress);
+        walletCtrl.addFunds(payload.to, payload.amount);
       } else {
-        // payload.nonce is not valid. Deduct gas anyway
-        // FIX ME: Waiting for scilla interpreter to return a structured output about out of gas errors
-        // https://github.com/Zilliqa/scilla/issues/214 
+        /* contract generation */
+        LOG_LOGIC('Task: Contract Deployment / Create Transaction');
+        // take the sha256 hash of address+nonce, then extract the rightmost 20 bytes
+        const contractAddr = computeContractAddr(senderAddress);
 
-        walletCtrl.deductFunds(senderAddress, payload.gasLimit)
-        LOG_LOGIC('Invalid Nonce')
-        throw new Error('Invalid Tx Json')
-      }
-
-      /*  Update Transactions */
-      const txnId = computeTransactionHash(payload)
-      LOG_LOGIC(`Transaction will be logged as ${txnId}`)
-      const txnDetails = {
-        ID: txnId,
-        amount: payload.amount,
-        nonce: payload.nonce,
-        senderPubKey: payload.pubKey,
-        signature: payload.signature,
-        toAddr: payload.to,
-        version: payload.version,
-      }
-      transactions[txnId] = txnDetails
-
-      return txnId
-    },
-
-    bootstrapFile: filepath => {
-      // bootstraps state of transactions and caddr owner
-      const data = JSON.parse(fs.readFileSync(filepath, 'utf-8'))
-      LOG_LOGIC('State of blockchain:')
-      transactions = data.transactions
-      LOG_LOGIC(transactions)
-    },
-
-    processGetTransaction: data => {
-      if (!data) {
-        LOG_LOGIC('Invalid params')
-        const err = new Error(
-          'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised'
-        )
-        throw err
-      }
-
-      LOG_LOGIC(`TxnID: ${data[0]}`)
-      const res = transactions[data[0]]
-      if (res) {
-        return res
-      }
-      throw new Error('Txn Hash not Present.')
-    },
-
-    processGetRecentTransactions: () => {
-      LOG_LOGIC('Getting Recent Transactions')
-
-      const txnhashes = Object.keys(transactions)
-      const responseObj = {}
-      responseObj.TxnHashes = txnhashes.reverse()
-      responseObj.number = txnhashes.length
-      return responseObj
-    },
-
-    processGetSmartContractInit: (data, saveMode) => {
-      LOG_LOGIC('Getting SmartContract Init')
-      if (!data) {
-        LOG_LOGIC('Invalid params')
-        const err = new Error(
-          'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised'
-        )
-        throw err
-      }
-
-      const contractAddress = data[0]
-      if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
-        console.log('Invalid request')
-        throw new Error('Address size inappropriate')
-      }
-
-      const dir = saveMode ? 'data/' : 'tmp/'
-      const initFile = `${dir}${contractAddress.toLowerCase()}_init.json`
-      if (!fs.existsSync(initFile)) {
-        console.log(`No init file found (Contract: ${contractAddress}`)
-        throw new Error('Address does not exist')
-      }
-      const retMsg = JSON.parse(fs.readFileSync(initFile, 'utf-8'))
-      return retMsg
-    },
-
-    processGetSmartContractCode: (data, saveMode) => {
-      LOG_LOGIC('Getting SmartContract code')
-      if (!data) {
-        LOG_LOGIC('Invalid params')
-        const err = new Error(
-          'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised'
-        )
-        throw err
-      }
-
-      const contractAddress = data[0]
-      if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
-        console.log('Invalid request')
-        throw new Error('Address size inappropriate')
-      }
-
-      const dir = saveMode ? 'data/' : 'tmp/'
-      const codePath = `${dir}${contractAddress.toLowerCase()}_code.scilla`
-      if (!fs.existsSync(codePath)) {
-        console.log(`No code file found (Contract: ${contractAddress}`)
-        throw new Error('Address does not exist')
-      }
-      LOG_LOGIC('Returning smart contract code to caller.')
-      const res = {}
-      res.code = fs.readFileSync(codePath, 'utf-8')
-      return res
-    },
-
-    processGetSmartContractState: (data, saveMode) => {
-      LOG_LOGIC('Getting SmartContract State')
-      if (!data) {
-        LOG_LOGIC('Invalid params')
-        const err = new Error(
-          'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised'
-        )
-        throw err
-      }
-
-      const contractAddress = data[0]
-      if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
-        console.log('Invalid request')
-        throw new Error('Address size inappropriate')
-      }
-
-      const dir = saveMode ? 'data/' : 'tmp/'
-      const statePath = `${dir}${contractAddress.toLowerCase()}_state.json`
-      if (!fs.existsSync(statePath)) {
-        console.log(`No state file found (Contract: ${contractAddress}`)
-        throw new Error('Address does not exist')
-      }
-      const retMsg = JSON.parse(fs.readFileSync(statePath, 'utf-8'))
-      LOG_LOGIC(retMsg)
-      return retMsg
-    },
-
-    /*
-getSmartContracts: Returns the list of smart contracts created by 
-an account
-*/
-    processGetSmartContracts: (data, saveMode) => {
-      if (!data) {
-        LOG_LOGIC('Invalid params')
-        const err = new Error(
-          'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised'
-        )
-        throw err
-      }
-
-      const addr = data[0]
-      console.log(`Getting smart contracts created by ${addr}`)
-      if (addr == null || !zilliqa.util.isAddress(addr)) {
-        console.log('Invalid request')
-        throw new Error('Address size inappropriate')
-      }
-
-      const stateLists = []
-      if (!createdContractsByUsers[addr]) {
-        throw new Error('Address does not exist')
-      }
-      // Addr found - proceed to append state to return list
-      const dir = saveMode ? 'data/' : 'tmp/'
-      const contracts = createdContractsByUsers[addr]
-      console.log(contracts)
-
-      contracts.forEach(contractId => {
-        const statePath = `${dir}${contractId.toLowerCase()}_state.json`
-        if (!fs.existsSync(statePath)) {
-          console.log(`No state file found (Contract: ${contractId}`)
-          throw new Error('Address does not exist')
+        if (checkOverflow(payload.gasLimit, payload.gasPrice)) {
+          throw new Error('Overflow detected: Invalid gas limit or gas price');
         }
-        const retMsg = JSON.parse(fs.readFileSync(statePath, 'utf-8'))
-        const contractStateObj = {}
-        contractStateObj.address = contractId
-        contractStateObj.state = retMsg
-        stateLists.push(contractStateObj)
-      })
+        const gasLimitToZil = payload.gasLimit * payload.gasPrice;
+        const gasAndAmount = payload.amount + gasLimitToZil;
 
-      return stateLists
-    },
-}
+        if (!walletCtrl.sufficientFunds(senderAddress, gasAndAmount)) {
+          LOG_LOGIC('Insufficient funds. Returning error to client.');
+          throw new Error('Insufficient funds');
+        }
+        LOG_LOGIC(`Contract will be deployed at: ${contractAddr}`);
+
+        const responseData = await scillaCtrl.executeScillaRun(
+          payload,
+          contractAddr,
+          dir,
+          currentBNum,
+          payload.gasLimit,
+        );
+        // Deduct funds
+        const nextAddr = responseData.nextAddress;
+        const gasConsumed = payload.gasLimit - responseData.gasRemaining;
+        if (checkOverflow(gasConsumed, payload.gasPrice)) {
+          throw new Error('Overflow detected: Invalid gas limit or gas price');
+        }
+        const gasConsumedInZil = gasConsumed * payload.gasPrice;
+
+        walletCtrl.deductFunds(
+          senderAddress,
+          payload.amount + gasConsumedInZil,
+        );
+        walletCtrl.increaseNonce(senderAddress); // only increase if a contract is successful
+
+        if (nextAddr !== '0'.repeat(40) && nextAddr.substring(2) !== senderAddress) {
+          console.log('Multi-contract calls not supported.');
+          throw new Error('Multi-contract calls are not supported yet.');
+        }
+
+        // Only update if it is a deployment call
+        if (payload.code && payload.to === '0'.repeat(40)) {
+          // Update address_to_contracts
+          if (senderAddress in createdContractsByUsers) {
+            LOG_LOGIC('User has contracts. Appending to list');
+            createdContractsByUsers[senderAddress].push(contractAddr);
+          } else {
+            LOG_LOGIC('No existing contracts. Creating new entry.');
+            createdContractsByUsers[senderAddress] = [contractAddr];
+          }
+          LOG_LOGIC('Addr-to-Contracts: %O', createdContractsByUsers);
+        }
+      }
+    } else {
+      // payload.nonce is not valid. Deduct gas anyway
+      // FIX ME: Waiting for scilla interpreter to return a structured output
+      // about out of gas errors
+      // https://github.com/Zilliqa/scilla/issues/214
+
+      walletCtrl.deductFunds(senderAddress, payload.gasLimit);
+      LOG_LOGIC('Invalid Nonce');
+      throw new Error('Invalid Tx Json');
+    }
+
+    /*  Update Transactions */
+    const txnId = computeTransactionHash(payload);
+    LOG_LOGIC(`Transaction will be logged as ${txnId}`);
+    const txnDetails = {
+      ID: txnId,
+      amount: payload.amount,
+      nonce: payload.nonce,
+      senderPubKey: payload.pubKey,
+      signature: payload.signature,
+      toAddr: payload.to,
+      version: payload.version,
+    };
+    transactions[txnId] = txnDetails;
+
+    return txnId;
+  },
+
+  bootstrapFile: (filepath) => {
+    // bootstraps state of transactions and caddr owner
+    const data = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+    LOG_LOGIC('State of blockchain:');
+    transactions = data.transactions;
+    LOG_LOGIC(transactions);
+  },
+
+  processGetTransaction: (data) => {
+    if (!data) {
+      LOG_LOGIC('Invalid params');
+      const err = new Error(
+        'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised',
+      );
+      throw err;
+    }
+
+    LOG_LOGIC(`TxnID: ${data[0]}`);
+    const res = transactions[data[0]];
+    if (res) {
+      return res;
+    }
+    throw new Error('Txn Hash not Present.');
+  },
+
+  processGetRecentTransactions: () => {
+    LOG_LOGIC('Getting Recent Transactions');
+
+    const txnhashes = Object.keys(transactions);
+    const responseObj = {};
+    responseObj.TxnHashes = txnhashes.reverse();
+    responseObj.number = txnhashes.length;
+    return responseObj;
+  },
+
+  processGetSmartContractInit: (data, saveMode) => {
+    LOG_LOGIC('Getting SmartContract Init');
+    if (!data) {
+      LOG_LOGIC('Invalid params');
+      const err = new Error(
+        'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised',
+      );
+      throw err;
+    }
+
+    const contractAddress = data[0];
+    if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
+      console.log('Invalid request');
+      throw new Error('Address size inappropriate');
+    }
+
+    const dir = saveMode ? 'data/' : 'tmp/';
+    const initFile = `${dir}${contractAddress.toLowerCase()}_init.json`;
+    if (!fs.existsSync(initFile)) {
+      console.log(`No init file found (Contract: ${contractAddress}`);
+      throw new Error('Address does not exist');
+    }
+    const retMsg = JSON.parse(fs.readFileSync(initFile, 'utf-8'));
+    return retMsg;
+  },
+
+  processGetSmartContractCode: (data, saveMode) => {
+    LOG_LOGIC('Getting SmartContract code');
+    if (!data) {
+      LOG_LOGIC('Invalid params');
+      const err = new Error(
+        'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised',
+      );
+      throw err;
+    }
+
+    const contractAddress = data[0];
+    if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
+      console.log('Invalid request');
+      throw new Error('Address size inappropriate');
+    }
+
+    const dir = saveMode ? 'data/' : 'tmp/';
+    const codePath = `${dir}${contractAddress.toLowerCase()}_code.scilla`;
+    if (!fs.existsSync(codePath)) {
+      console.log(`No code file found (Contract: ${contractAddress}`);
+      throw new Error('Address does not exist');
+    }
+    LOG_LOGIC('Returning smart contract code to caller.');
+    const res = {};
+    res.code = fs.readFileSync(codePath, 'utf-8');
+    return res;
+  },
+
+  processGetSmartContractState: (data, saveMode) => {
+    LOG_LOGIC('Getting SmartContract State');
+    if (!data) {
+      LOG_LOGIC('Invalid params');
+      const err = new Error(
+        'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised',
+      );
+      throw err;
+    }
+
+    const contractAddress = data[0];
+    if (contractAddress == null || !zilliqa.util.isAddress(contractAddress)) {
+      console.log('Invalid request');
+      throw new Error('Address size inappropriate');
+    }
+
+    const dir = saveMode ? 'data/' : 'tmp/';
+    const statePath = `${dir}${contractAddress.toLowerCase()}_state.json`;
+    if (!fs.existsSync(statePath)) {
+      console.log(`No state file found (Contract: ${contractAddress}`);
+      throw new Error('Address does not exist');
+    }
+    const retMsg = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+    LOG_LOGIC(retMsg);
+    return retMsg;
+  },
+
+  /*
+getSmartContracts: Returns the list of smart contracts created by an account
+*/
+  processGetSmartContracts: (data, saveMode) => {
+    if (!data) {
+      LOG_LOGIC('Invalid params');
+      const err = new Error(
+        'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised',
+      );
+      throw err;
+    }
+
+    const addr = data[0];
+    console.log(`Getting smart contracts created by ${addr}`);
+    if (addr == null || !zilliqa.util.isAddress(addr)) {
+      console.log('Invalid request');
+      throw new Error('Address size inappropriate');
+    }
+
+    const stateLists = [];
+    if (!createdContractsByUsers[addr]) {
+      throw new Error('Address does not exist');
+    }
+    // Addr found - proceed to append state to return list
+    const dir = saveMode ? 'data/' : 'tmp/';
+    const contracts = createdContractsByUsers[addr];
+    console.log(contracts);
+
+    contracts.forEach((contractId) => {
+      const statePath = `${dir}${contractId.toLowerCase()}_state.json`;
+      if (!fs.existsSync(statePath)) {
+        console.log(`No state file found (Contract: ${contractId}`);
+        throw new Error('Address does not exist');
+      }
+      const retMsg = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+      const contractStateObj = {};
+      contractStateObj.address = contractId;
+      contractStateObj.state = retMsg;
+      stateLists.push(contractStateObj);
+    });
+
+    return stateLists;
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -238,7 +237,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -246,8 +244,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -286,8 +283,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.1",
@@ -298,14 +294,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -1149,7 +1143,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1161,6 +1154,11 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
+    },
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1346,8 +1344,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
@@ -1481,8 +1478,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1523,7 +1519,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1604,8 +1599,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.4",
@@ -1679,7 +1673,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1821,8 +1814,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1877,7 +1869,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -2598,8 +2589,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2656,14 +2646,12 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-diff": {
       "version": "1.1.2",
@@ -2674,8 +2662,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2813,14 +2800,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
@@ -3430,7 +3415,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3531,14 +3515,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "dev": true,
       "requires": {
         "ajv": "^5.3.0",
         "har-schema": "^2.0.0"
@@ -3693,7 +3675,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -4072,8 +4053,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -4130,8 +4110,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.3.1",
@@ -5231,7 +5210,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -5277,14 +5255,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5295,8 +5271,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
@@ -5308,7 +5283,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -5392,8 +5366,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5744,8 +5717,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6056,8 +6028,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -6242,8 +6213,7 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
-      "dev": true
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -6521,7 +6491,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6546,33 +6515,40 @@
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.35.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
-          "dev": true
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
         },
         "mime-types": {
-          "version": "2.1.19",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
-          "dev": true,
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
           "requires": {
-            "mime-db": "~1.35.0"
+            "mime-db": "~1.36.0"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
       "requires": {
         "lodash": "^4.13.1"
       }
@@ -7383,7 +7359,6 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7431,8 +7406,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-length": {
       "version": "2.0.0",
@@ -8104,7 +8078,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -8113,8 +8086,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -8143,7 +8115,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -8152,7 +8123,6 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -8377,8 +8347,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -8413,7 +8382,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,6 +2177,15 @@
         "object.entries": "^1.0.4"
       }
     },
+    "eslint-config-prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz",
+      "integrity": "sha512-vA0TB8HCx/idHXfKHYcg9J98p0Q8nkfNwNAoP7e+ywUidn6ScaFS5iqncZAHPz+/a0A/tp657ulFHFx/2JDP4Q==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -2301,6 +2310,24 @@
           "requires": {
             "path-parse": "^1.0.5"
           }
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
+      },
+      "dependencies": {
+        "jest-docblock": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+          "dev": true
         }
       }
     },
@@ -2636,6 +2663,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -3375,6 +3408,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -6123,6 +6162,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "hash.js": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "node-fs": "^0.1.7",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.2",
     "rimraf": "^2.6.2",
     "yargs": "^12.0.1",
     "zilliqa-js": "^0.1.8"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "cross-env": "^5.2.0",
     "eslint": "^5.5.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-prettier": "^3.0.1",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-prettier": "^2.6.2",
     "jest": "^23.5.0",
+    "prettier": "^1.14.2",
     "superagent": "^3.8.3",
     "supertest": "^3.1.0"
   },

--- a/server.js
+++ b/server.js
@@ -15,17 +15,23 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-let colors = require('colors');
-
 const config = require('./config');
+
+/* Information about Kaya RPC Server */
+
+console.log(`ZILLIQA KAYA RPC SERVER (ver: ${config.version})`);
+console.log(`Server listening on 127.0.0.1:${config.port}`);
+
+if (config.scilla.remote) {
+  console.log(`Scilla interperter running remotely from: ${config.scilla.url}`);
+} else {
+  console.log('Scilla interpreter running locally');
+}
+console.log('='.repeat(80));
+
 const app = require('./app');
 
-const { port } = config;
-
-console.log(`Zilliqa kaya Server (ver: ${config.version})`.cyan);
-console.log(`\nServer listening on 127.0.0.1:${port}`.yellow);
-
-const server = app.expressjs.listen(port, err => {
+const server = app.expressjs.listen(config.port, (err) => {
   if (err) {
     process.exit(1);
   }
@@ -33,7 +39,7 @@ const server = app.expressjs.listen(port, err => {
 
 // Listener for connections opening on the server
 let connections = [];
-server.on('connection', connection => {
+server.on('connection', (connection) => {
   connections.push(connection);
   connection.on(
     'close',

--- a/server.js
+++ b/server.js
@@ -15,28 +15,28 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-let colors = require('colors')
+let colors = require('colors');
 
-const config = require('./config')
-const app = require('./app')
+const config = require('./config');
+const app = require('./app');
 
-const { port } = config
+const { port } = config;
 
-console.log(`Zilliqa kaya Server (ver: ${config.version})`.cyan)
-console.log(`\nServer listening on 127.0.0.1:${port}`.yellow)
+console.log(`Zilliqa kaya Server (ver: ${config.version})`.cyan);
+console.log(`\nServer listening on 127.0.0.1:${port}`.yellow);
 
 const server = app.expressjs.listen(port, err => {
   if (err) {
-    process.exit(1)
+    process.exit(1);
   }
-})
+});
 
 // Listener for connections opening on the server
-let connections = []
+let connections = [];
 server.on('connection', connection => {
-  connections.push(connection)
+  connections.push(connection);
   connection.on(
     'close',
-    () => (connections = connections.filter(curr => curr !== connection))
-  )
-})
+    () => (connections = connections.filter(curr => curr !== connection)),
+  );
+});

--- a/test/scripts/CreateTransaction.js
+++ b/test/scripts/CreateTransaction.js
@@ -82,7 +82,7 @@ const txnDetails = {
   nonce: 2,
   to: argv.to,
   amount: new BN(0),
-  gasPrice: 0,
+  gasPrice: 1,
   gasLimit: 100,
   data: JSON.stringify(msg).replace(/\\"/g, '"'),
 };

--- a/test/scripts/CreateTransaction.js
+++ b/test/scripts/CreateTransaction.js
@@ -27,20 +27,30 @@ const zilliqa = new Zilliqa({
 });
 
 let privateKey;
-// User supplies the private key through `--key`
-if (argv.key) {
-  privateKey = argv.key;
-  console.log(`Your Private Key: ${privateKey} \n`);
+let recipient;
+
+if (argv.test) {
+  // test mode uses keys from the account fixtures
+  privateKey = 'db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3';
+  recipient = 'cef48d2ec4086bd5799b659261948daab02b760d';
 } else {
-  console.log('No private key given! Generating random privatekey.'.green);
-  privateKey = zilliqa.util.generatePrivateKey();
-  console.info(`Your Private Key: ${privateKey.toString('hex')}`);
+  // User supplies the private key through `--key`
+  if (argv.key) {
+    privateKey = argv.key;
+    console.log(`Your Private Key: ${privateKey} \n`);
+  } else {
+    console.log('No private key given! Generating random privatekey.'.green);
+    privateKey = zilliqa.util.generatePrivateKey();
+    console.info(`Your Private Key: ${privateKey.toString('hex')}`);
+  }
+
+  if (!argv.to) {
+    console.log('To address required');
+    process.exit(0);
+  }
+  recipient = argv.to;
 }
 
-if (!argv.to) {
-  console.log('To address required');
-  process.exit(0);
-}
 
 const address = zilliqa.util.getAddressFromPrivateKey(privateKey);
 
@@ -57,7 +67,7 @@ function callback(err, data) {
 
 /*  MAIN LOGIC  */
 
-console.log('Zilliqa Testing Script'.bold.cyan);
+console.log('Zilliqa Testing Script');
 console.log(`Connected to ${url}`);
 
 /* Contract specific Parameters */
@@ -67,23 +77,21 @@ const msg = {
   _tag: 'setHello',
   _amount: '0',
   _sender: '0x7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
-  params: [
-    {
-      vname: 'msg',
-      type: 'String',
-      value: 'Morning',
-    },
-  ],
+  params: [{
+    vname: 'msg',
+    type: 'String',
+    value: 'Morning',
+  }],
 };
 
 // transaction details
 const txnDetails = {
   version: 0,
   nonce: 2,
-  to: argv.to,
+  to: recipient,
   amount: new BN(0),
   gasPrice: 1,
-  gasLimit: 100,
+  gasLimit: 2000,
   data: JSON.stringify(msg).replace(/\\"/g, '"'),
 };
 

--- a/test/scripts/DeployContract.js
+++ b/test/scripts/DeployContract.js
@@ -15,7 +15,6 @@
   kaya.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 require('isomorphic-fetch');
 const { Zilliqa } = require('zilliqa-js');
 const fs = require('fs');
@@ -28,14 +27,19 @@ const zilliqa = new Zilliqa({
 });
 
 let privateKey;
-// User supplies the private key through `--key`
-if (argv.key) {
-  privateKey = argv.key;
-  console.log(`Your Private Key: ${privateKey} \n`);
+
+if (argv.test) {
+  privateKey = 'db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3';
 } else {
-  console.log('No private key given! Generating random privatekey.'.green);
-  privateKey = zilliqa.util.generatePrivateKey();
-  console.info(`Your Private Key: ${privateKey.toString('hex')}`);
+  // User supplies the private key through `--key`
+  if (argv.key) {
+    privateKey = argv.key;
+    console.log(`Your Private Key: ${privateKey} \n`);
+  } else {
+    console.log('No private key given! Generating random privatekey.');
+    privateKey = zilliqa.util.generatePrivateKey();
+    console.info(`Your Private Key: ${privateKey.toString('hex')}`);
+  }
 }
 
 const address = zilliqa.util.getAddressFromPrivateKey(privateKey);
@@ -46,7 +50,7 @@ console.log(`Pubkey:  ${zilliqa.util.getPubKeyFromPrivateKey(privateKey)}`);
 
 function callback(err, data) {
   if (err || data.error) {
-    console.log('Error');
+    console.log(err);
   } else {
     console.log(data);
   }
@@ -60,7 +64,7 @@ console.log(`Connected to ${url}`);
 
 /* Contract specific Parameters */
 
-const codeStr = fs.readFileSync('contract_nomsg.scilla', 'utf-8');
+const codeStr = fs.readFileSync('contract.scilla', 'utf-8');
 // the immutable initialisation variables
 const initParams = [
   {
@@ -82,7 +86,7 @@ const txnDetails = {
   to: '0000000000000000000000000000000000000000',
   amount: new BN(0),
   gasPrice: 1,
-  gasLimit: 16,
+  gasLimit: 2000,
   code: codeStr,
   data: JSON.stringify(initParams).replace(/\\' /g, '"'),
 };

--- a/test/scripts/DeployContract.js
+++ b/test/scripts/DeployContract.js
@@ -55,7 +55,7 @@ function callback(err, data) {
 /*
      MAIN LOGIC
 */
-console.log('Zilliqa Testing Script'.bold.cyan);
+console.log('Zilliqa Testing Script');
 console.log(`Connected to ${url}`);
 
 /* Contract specific Parameters */

--- a/test/scripts/contract.scilla
+++ b/test/scripts/contract.scilla
@@ -4,6 +4,8 @@
 (***************************************************)
 (*               Associated library                *)
 (***************************************************)
+import ListUtils
+
 library HelloWorld
 
 let one_msg = 

--- a/utilities.js
+++ b/utilities.js
@@ -17,44 +17,44 @@
 
 module.exports = {
   removeComments: str => {
-    let commentStart
-    let commentEnd
-    let str1
-    let str2
-    let str3
-    const originalStr = str
+    let commentStart;
+    let commentEnd;
+    let str1;
+    let str2;
+    let str3;
+    const originalStr = str;
 
     try {
       // loop till all comments beginning with '(*' are removed
       while ((commentStart = str.match(/\(\*/))) {
         // get the string till comment start
-        str1 = str.substr(0, commentStart.index)
+        str1 = str.substr(0, commentStart.index);
 
         // get the string after comment start
-        str2 = str.substr(commentStart.index)
-        commentEnd = str2.match(/\*\)/)
-        str3 = str2.substr(commentEnd.index + 2)
+        str2 = str.substr(commentStart.index);
+        commentEnd = str2.match(/\*\)/);
+        str3 = str2.substr(commentEnd.index + 2);
 
-        str = str1 + str3
+        str = str1 + str3;
       }
     } catch (e) {
-      return originalStr
+      return originalStr;
     }
-    return str
+    return str;
   },
 
   codeCleanup: str => {
-    let cleanedCode = module.exports.removeComments(str)
-    cleanedCode = cleanedCode.replace(/\\n/g, ' ').replace(/\\"/g, '"')
-    cleanedCode = cleanedCode.substring(1, cleanedCode.length - 1)
-    return cleanedCode
+    let cleanedCode = module.exports.removeComments(str);
+    cleanedCode = cleanedCode.replace(/\\n/g, ' ').replace(/\\"/g, '"');
+    cleanedCode = cleanedCode.substring(1, cleanedCode.length - 1);
+    return cleanedCode;
   },
 
   paramsCleanup: initParams => {
-    let cleanedParams = initParams.trim()
+    let cleanedParams = initParams.trim();
     cleanedParams = cleanedParams
       .substring(1, cleanedParams.length - 1)
-      .replace(/\\"/g, '"')
-    return cleanedParams
+      .replace(/\\"/g, '"');
+    return cleanedParams;
   },
-}
+};


### PR DESCRIPTION
## Description
- Resolves #13 . Kaya RPC can now use the scilla interpreter from the remote server. With remote server enabled by default, Kaya RPC now works out-of-the-box without needing to make the scilla interpreter themselves. 
- Developers working on Windows will now be able to use Kaya RPC to quickly develop and prototype their applications. As Scilla is actively developed on ubuntu/MacOS, official support for Windows is not available.
- Added `--test` flag for test scripts to use configurations in account fixture files. 

## Review Suggestion
1. Run `npm test`

You can also use the `--test` flag for the manual testing, which uses default test configurations: 
1. Start the server using `npm run debug:fixtures`
2. Deploy a contract using `node DeployContract.js --test`.
3. Check where the contract is deployed. It should be on the logs if you have enabled `debug` mode, otherwise you can check it through the `GetSmartContracts` method.
4. Send a transaction using `node CreateTransaction.js --test`

## Status

### Implementation
- [x] **ready for review**
