### PR TITLE
Feature: draft for a dockerized Kaya RPC which tries to resolve #31

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: node_js
-sudo: true
-node_js: 
-  - "stable"
+sudo: required
+service:
+- docker
+node_js:
+- stable
+before_install:
+- curl -L https://goss.rocks/install | sudo sh
+- docker build -t visibilityspots/openstackclient-kilo .
 install:
-  - npm install
+- npm install
 script:
-  - npm run test
+- npm run test
+after_success:
+- if [ "$TRAVIS_BRANCH" == "master" ]; then docker login -u=visibilityspots -p="$DOCKER_PASSWORD";
+  docker push visibilityspots/kaya-rpc; fi
 cache:
   directories:
-    - $HOME/.npm
+  - "$HOME/.npm"
+env:
+  global:
+    secure: anqO8o+QQVLp7ETDbuFm0wJZlYrk3vq3v1wIudpFnidl+bf5FSM8BANIaLlzg9ktPitw+c5abM92QKO8ZWISw8QgJ5zX+JDUiyH4yff1mnEy1jMr4HDOjPg5zpdogkzXAoc3LH1SuraKNaR03ViL8+bUPKn2SEAlp0xBQ99eiyfZX7or2BYOVEHB9TENztOQ/honBOJyJMdHegq92izQ1qOFrOi83blenRA8LIzNzMIn+Mb1ZfrAlvfj4OeGIXRgGAnOQQ7ZyWwru/HxJxA+7baHX3tye4j2HM3i7JKQyPDUm0xICasIfg0bHvXFxxWrND2zR0lRkhm2cR61ygxBHEhBbuWY7R7fiQN5pv+0LvyQd3YNBgTXkM4Ky2M3RDjm9sHenlSCTrRHrDHO+BBNi6fKVz8iU1FD8ARy+g2QYkPsGzm7JxofOHOE4s1QAIQxOYj8BjGNhR/kS64xDzaHFn/wXyz/gbvFmDM8ClYBS3b4u7L+RA5lZ9yD5iZ4fRMeD4Ew/rjDsLiodH9Avn01SCfvHPmV6ZoFOMVW8GRh4qYwGYx3aQ6FGd5MrS3jNKp7PTsI4hx46XofXFubxWhAWd0NUkKu5xU+DU2hyUrlSmsLwMGG4nXhHRzE+3SWXx1Lwr66Sgdlnz6Y7NgBMKCwf90Q4BRZyT4yxRdd455eM/0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 - stable
 before_install:
 - curl -L https://goss.rocks/install | sudo sh
-- docker build -t visibilityspots/openstackclient-kilo .
+- docker build -t visibilityspots/kaya-rpc .
 install:
 - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 - docker build -t visibilityspots/kaya-rpc .
 install:
 - npm install
-script:
-- npm run test
+#script:
+#- npm run test
 after_success:
 - if [ "$TRAVIS_BRANCH" == "master" ]; then docker login -u=visibilityspots -p="$DOCKER_PASSWORD";
   docker push visibilityspots/kaya-rpc; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 - docker build -t visibilityspots/kaya-rpc .
 install:
 - npm install
-#script:
-#- npm run test
+script:
+- npm run test
 after_success:
 - if [ "$TRAVIS_BRANCH" == "master" ]; then docker login -u=visibilityspots -p="$DOCKER_PASSWORD";
   docker push visibilityspots/kaya-rpc; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,47 @@
-FROM node:10.11.0-slim
+FROM node:10.11.0-stretch as builder
 
+WORKDIR /tmp/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends build-essential \
+    && apt-get install -y --no-install-recommends m4 \
+    && apt-get install -y --no-install-recommends aspcud \
+    && apt-get install -y --no-install-recommends ocaml \
+    && apt-get install -y --no-install-recommends opam \
+    && apt-get install -y --no-install-recommends pkg-config \
+    && apt-get install -y --no-install-recommends zlib1g-dev \
+    && apt-get install -y --no-install-recommends libgmp-dev \
+    && apt-get install -y --no-install-recommends libffi-dev \
+    && apt-get install -y --no-install-recommends libssl-dev \
+    && apt-get install -y --no-install-recommends libboost-system-dev \
+    && apt-get install -y --no-install-recommends apt-transport-https \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends software-properties-common \
+    && apt-get install -y --no-install-recommends git \
+    && cd /tmp/ \
+    && git clone https://github.com/Zilliqa/scilla.git \
+    && cd scilla \
+    && make opamdep \
+    && eval `opam config env` \
+    && make clean; make \
+    && make test
+
+FROM node:10.11.0-stretch as runtime
 WORKDIR /usr/src/app
-
+ENV PORT 4200
+ENV REMOTE true
 COPY package*.json ./
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && chown node: /usr/src/app
+
+USER node
 
 RUN npm install
 
 COPY . .
+COPY --from=builder /tmp/scilla/bin/scilla-runner /usr/src/app/bin/
 
-EXPOSE 4200
-
-CMD  [ "node", "server.js", "--save" ]
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10.11.0-slim
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 4200
+
+CMD  [ "node", "server.js", "--save" ]

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ a Dockerfile has been created to build a docker image which can be used to start
 
 `$ docker build -t kaya .`
 
-and run it afterwards:
+and run it afterwards with the defaults on port 4200, debugging false and against a remote scilla interperter:
 
 `
-$ docker run --rm -d --name kay-local -p 4200:4200 kaya
+$ docker run --rm -d -p 4200:4200 kaya
 
 $ docker logs -f kaya-local
 docker run --rm -p 4200:4200 kaya
@@ -141,43 +141,43 @@ $ curl http://localhost:4200
 Kaya RPC Server%
 `
 
-or fetch it from the automated build
+or run it with some custom parameters to enable debugging, a custom port and against a local scilla interpereter.
 
 `
-$ docker run --rm -d --name kaya-upstream -p 4200:4200 visibilityspots/kaya-rpc:latest
+$ docker run --rm -p 5000:5000 -e PORT="5000" -e REMOTE="false" kaya:latest --debug
 
-$ docker logs -f kaya-upstream
 ZILLIQA KAYA RPC SERVER (ver: 0.2.0)
-Server listening on 127.0.0.1:4200
-Scilla interperter running remotely from: https://scilla-runner.zilliqa.com/contract/call
+Server listening on 127.0.0.1:5000
+Scilla interpreter running locally
 ================================================================================
 Available Accounts
 =============================
-(0) fd9905cf96dec76949292ebd9bf066bacdca648e (Amt: 100000) (Nonce: 0)
-(1) 1fa618bffd884dc99bf73b551818237d90196454 (Amt: 100000) (Nonce: 0)
-(2) 334dffaa1e7283f08d659a7d82cec558675021b6 (Amt: 100000) (Nonce: 0)
-(3) a2663fbdd33e52ae35b780b5188544366f272920 (Amt: 100000) (Nonce: 0)
-(4) 9366fc14a80be3ed46154f9990ea49e00825ba31 (Amt: 100000) (Nonce: 0)
-(5) a1743a68dc75913e82ab6bccc65e994aa7a2bd3b (Amt: 100000) (Nonce: 0)
-(6) 81543d1cf83c1cbcce24dcb1ef8706cea5762843 (Amt: 100000) (Nonce: 0)
-(7) d1ec7854a4bdf2453559dd967b037c5620e2afc8 (Amt: 100000) (Nonce: 0)
-(8) bda52dbf7435e97787560d89cdf971016498e987 (Amt: 100000) (Nonce: 0)
-(9) 89bdcfced980f99b2ff009afdd69cc5f71c82127 (Amt: 100000) (Nonce: 0)
+(0) 6b20c0cb05228d6461eda3290e0dcffac224557f (Amt: 100000) (Nonce: 0)
+(1) 4c6835acab74b6fe79642f7cd77135c957581413 (Amt: 100000) (Nonce: 0)
+(2) a37243176688a70f9942cdd09152accdbd95bf8a (Amt: 100000) (Nonce: 0)
+(3) fc1f02454bb972d9ce28a787a47afb81280fe586 (Amt: 100000) (Nonce: 0)
+(4) ce6d38378c41a086dd0181c22819d8948961e426 (Amt: 100000) (Nonce: 0)
+(5) 82746cba7b213851e89a6edb1b2617b19c509ed7 (Amt: 100000) (Nonce: 0)
+(6) 2535fccbddaad3234c719080fbeedfe6acd0855e (Amt: 100000) (Nonce: 0)
+(7) 9a769c1aa062ffa0074cda3c751df1e9073da103 (Amt: 100000) (Nonce: 0)
+(8) afb3a62f3f166a9107b7d59a9bc60a4a092fdf0f (Amt: 100000) (Nonce: 0)
+(9) bf6a645e533696ad6184c6890dd2e03f703b8979 (Amt: 100000) (Nonce: 0)
 
  Private Keys
  =============================
- (0) 0f3f87a5de0ed3f2f2f820f29329dac6cdf3441f509a17fc691dd685a774ad0d
- (1) 63b8fcf20369e52d30a9349391c9882e0b0fb233016681b73a00841feb10c119
- (2) a4432a8ab8364d67f643297ebdf96715ffdfe7aaa7640c03d69aaa56e318dd31
- (3) 78c08ac47ff61e93fcc8756ecd867fe1bdde63e64818819e900da67ce22294eb
- (4) b407ab787e6f25f48fce0b5e069ae16ab1df41f8cc1825a3b26c0319927b5f1f
- (5) 76b3325c8748c6053bd5f17f73b673fcaed338911a51dc64feddd0e5151f55bc
- (6) db0123b9a3c5c99af8c5955dbcd59b723c5291ba2fe8a502c8ffb9a529ee7428
- (7) a1c5e235070f9898a47f814728f0a9111068eaace15e4f3bb0e938658ccfa3aa
- (8) 54ec3f82d12fd3bf3c1e205045b8ebca63768abd3dd8ac66f4cbb754a3bc6fcc
- (9) d1e95e1ec1c398308f12c7b4fc8070f75ace08baf977deffac72fa25441ecb4d
+ (0) 5dca73222536b068c4de37ebce3f309218d254b39afde984f28d0fe133d8edfd
+ (1) 64540242416897b42e024ee7c92cc54bc1222437aae37043eb94eb9f50b1a670
+ (2) f1d3607480889a40ebe6d7b5a7e2f35b887eedd5c14a58440cc13e1d3273505c
+ (3) 3e9b86c0999c3e8e9c86b88d500218f7c2899101bd395fe6cef777c2ec975e78
+ (4) 6fc03a088b6f5ad0fd6cdd98bfa48535102b3be2fdffe8a2c3f4a11dd2fec3fb
+ (5) 78e57fb6be4b039b3d767eb9f4c94c9c94c2458af4c2058500b28953d399f05c
+ (6) 5fffdebf924952416efa4992699bcc144abb788d4a2164e124df9acae7048732
+ (7) 07eb4be6ad36ac255f6401580dd4ac6ef81e429b06c8ae2aabf87201b6a8be39
+ (8) 6670b623d93d52cb8d610d0fc68f4862b48cb90426a4cd4b837374e424d8349e
+ (9) eb5f1e20dfbe52982e22443c5e1360338aec0f6d99a101c475f3a4139cb615d5
 
-$ curl http://localhost:4200
+
+$ curl http://localhost:5000
 Kaya RPC Server%
 `
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Kaya is Zilliqa's RPC server for testing and development. It is personal blockch
 
 The goal of the project is to support all endpoints in Zilliqa Javascript API, making it easy for app developers to build Dapps on our platform.
 
-Kaya is under development. See [roadmap here](https://github.com/Zilliqa/kaya/blob/master/ROADMAP.md). 
+Kaya is under development. See [roadmap here](https://github.com/Zilliqa/kaya/blob/master/ROADMAP.md).
 
 Currently, Kaya supports the following functions:
 * `CreateTransaction`
@@ -34,16 +34,16 @@ In addition, the following features are not supported yet:
 ### Installation
 Install the node packages and dependencies: `npm install`
 
-Scilla files must be processed using the `scilla-interpreter`. The [Scilla interpreter](https://scilla.readthedocs.io/en/latest/interface.html) executable provides a calling interface that enables users to invoke transitions with specified inputs and obtain outputs. 
+Scilla files must be processed using the `scilla-interpreter`. The [Scilla interpreter](https://scilla.readthedocs.io/en/latest/interface.html) executable provides a calling interface that enables users to invoke transitions with specified inputs and obtain outputs.
 
 #### Using Remote Scilla Interpreter (Default)
 
 By default, Kaya RPC uses the remote scilla interpreter to process `.scilla` files. You do not have to change any configurations.
 
 #### Using Local Scilla Interpreter
-You can choose to use your own scilla interpreter locally. To do it, you will have to compile the binary yourself from the [scilla repository](https://github.com/Zilliqa/scilla) and transfer it to the correct directory within Kaya RPC. 
+You can choose to use your own scilla interpreter locally. To do it, you will have to compile the binary yourself from the [scilla repository](https://github.com/Zilliqa/scilla) and transfer it to the correct directory within Kaya RPC.
 
-Instructions: 
+Instructions:
 1. Ensure that you have installed the related dependencies: [INSTALL.md](https://github.com/Zilliqa/scilla/blob/master/INSTALL.md)
 2. Then, run `make clean; make`
 3. Copy the `scilla-runner` from `[SCILLA_DIR]/bin` into `[Kaya_DIR]/components/scilla/`
@@ -80,19 +80,106 @@ node server.js --load data/save/YYYYMMDDhhmmss_blockchain_states.json
 
 Some of the functions in Kaya RPC are covered under automated testing using `jest`. However, scilla related transactions are not covered through automated testing. To test the `CreateTransaction` functionalities, you will have to test it manually.
 
-From `test/scripts/`, you can use run `node DeployContract.js` to test contract deployment. 
-Then, use `node CreateTransaction --key [private-key] --to [contract_addr]` to make transition calls. 
+From `test/scripts/`, you can use run `node DeployContract.js` to test contract deployment.
+Then, use `node CreateTransaction --key [private-key] --to [contract_addr]` to make transition calls.
 You can use the `curl` commands stated in the [jsonrpc apidocs](https://apidocs.zilliqa.com/#introduction) to test the rest of the functions.
 
 Use `--key` to specify a private key. Otherwise, a random privatekey will be generated.
 
 ### Testing with Fixture Files
 
-You can also use the `--test` flag, which uses default test configurations: 
+You can also use the `--test` flag, which uses default test configurations:
 1. Start the server using `npm run debug:fixtures`
 2. Deploy a contract using `node DeployContract.js --test`.
 3. Check where the contract is deployed. It should be on the logs if you have enabled `debug` mode, otherwise you can check it through the `GetSmartContracts` method.
 4. Send a transaction using `node CreateTransaction.js --test`
+
+## Docker
+
+a Dockerfile has been created to build a docker image which can be used to start Kaya RPC within a docker container. You can build the docker image on your local machine:
+
+`$ docker build -t kaya .`
+
+and run it afterwards:
+
+`
+$ docker run --rm -d --name kay-local -p 4200:4200 kaya
+
+$ docker logs -f kaya-local
+docker run --rm -p 4200:4200 kaya
+ZILLIQA KAYA RPC SERVER (ver: 0.2.0)
+Server listening on 127.0.0.1:4200
+Scilla interperter running remotely from: https://scilla-runner.zilliqa.com/contract/call
+================================================================================
+Available Accounts
+=============================
+(0) 16cc5cfaeff4945fc2edc1f9a73c1ba38f3a169c (Amt: 100000) (Nonce: 0)
+(1) 9ba385bfdfa5aaa15f638702c99c917961b7fa99 (Amt: 100000) (Nonce: 0)
+(2) 394b0e1863315841d4c3acf40a8dc6d9537e558e (Amt: 100000) (Nonce: 0)
+(3) f593719f912cf12ce438608f9131b5126ab25873 (Amt: 100000) (Nonce: 0)
+(4) 25b2d997b8b1a20302a8a749c35a14e36495856d (Amt: 100000) (Nonce: 0)
+(5) f4cd38f387465505a316be8f552f61f3140970d7 (Amt: 100000) (Nonce: 0)
+(6) 844f41fafd3181f821d7ec8d70073fca862762f5 (Amt: 100000) (Nonce: 0)
+(7) 1e15ea5841c856318455a682db0d5587ea18cfd2 (Amt: 100000) (Nonce: 0)
+(8) e7d8fd2d2706f1f5ea55181a90757285b317596d (Amt: 100000) (Nonce: 0)
+(9) 4679743b469257d1fcf3c3ed1fa436d039bab446 (Amt: 100000) (Nonce: 0)
+
+ Private Keys
+ =============================
+ (0) da6e6d128720a4d2c97677718b2cb2749e5b6ad89ef5c0bf91084658b55e84a5
+ (1) 22f92cf224b77b8cb4b8a524ed78a378ddb278abf8f3415e600116df94dac26a
+ (2) c3c14bcb74d4146f1dd8d1e17ccd4266641634b22971edbcdddb495c1c837e9a
+ (3) 67846d97dd865fe681a79a1ce1f2687d054d521457d03bd5e4466b1147a2c108
+ (4) 3b3627cb909de680eebf34131ab703fb6fc5e5295475579212c2c727cccbeecc
+ (5) 59e1579f2e41a80e2b31e9e0ab59419eb733be8d8b2aaebcbb7f917d3b305ac9
+ (6) d811444994f8337d4229ea9acda1ee2af9fe43155d91e1dd8d34b1968ab53a9e
+ (7) c3bbddbdc662769760f7220fec925dc407afdd2dd1a166370402d09057418bb7
+ (8) 4429129188cccaf9152e52371ee09cdd7a13fb0bea9048cf6f58f89886572dd1
+ (9) 78043ccc1ae0fd67de67e48b43f1cec7260294d35ab9ce844ca05a50bb9bb45c
+
+$ curl http://localhost:4200
+Kaya RPC Server%
+`
+
+or fetch it from the automated build
+
+`
+$ docker run --rm -d --name kaya-upstream -p 4200:4200 visibilityspots/kaya-rpc:latest
+
+$ docker logs -f kaya-upstream
+ZILLIQA KAYA RPC SERVER (ver: 0.2.0)
+Server listening on 127.0.0.1:4200
+Scilla interperter running remotely from: https://scilla-runner.zilliqa.com/contract/call
+================================================================================
+Available Accounts
+=============================
+(0) fd9905cf96dec76949292ebd9bf066bacdca648e (Amt: 100000) (Nonce: 0)
+(1) 1fa618bffd884dc99bf73b551818237d90196454 (Amt: 100000) (Nonce: 0)
+(2) 334dffaa1e7283f08d659a7d82cec558675021b6 (Amt: 100000) (Nonce: 0)
+(3) a2663fbdd33e52ae35b780b5188544366f272920 (Amt: 100000) (Nonce: 0)
+(4) 9366fc14a80be3ed46154f9990ea49e00825ba31 (Amt: 100000) (Nonce: 0)
+(5) a1743a68dc75913e82ab6bccc65e994aa7a2bd3b (Amt: 100000) (Nonce: 0)
+(6) 81543d1cf83c1cbcce24dcb1ef8706cea5762843 (Amt: 100000) (Nonce: 0)
+(7) d1ec7854a4bdf2453559dd967b037c5620e2afc8 (Amt: 100000) (Nonce: 0)
+(8) bda52dbf7435e97787560d89cdf971016498e987 (Amt: 100000) (Nonce: 0)
+(9) 89bdcfced980f99b2ff009afdd69cc5f71c82127 (Amt: 100000) (Nonce: 0)
+
+ Private Keys
+ =============================
+ (0) 0f3f87a5de0ed3f2f2f820f29329dac6cdf3441f509a17fc691dd685a774ad0d
+ (1) 63b8fcf20369e52d30a9349391c9882e0b0fb233016681b73a00841feb10c119
+ (2) a4432a8ab8364d67f643297ebdf96715ffdfe7aaa7640c03d69aaa56e318dd31
+ (3) 78c08ac47ff61e93fcc8756ecd867fe1bdde63e64818819e900da67ce22294eb
+ (4) b407ab787e6f25f48fce0b5e069ae16ab1df41f8cc1825a3b26c0319927b5f1f
+ (5) 76b3325c8748c6053bd5f17f73b673fcaed338911a51dc64feddd0e5151f55bc
+ (6) db0123b9a3c5c99af8c5955dbcd59b723c5291ba2fe8a502c8ffb9a529ee7428
+ (7) a1c5e235070f9898a47f814728f0a9111068eaace15e4f3bb0e938658ccfa3aa
+ (8) 54ec3f82d12fd3bf3c1e205045b8ebca63768abd3dd8ac66f4cbb754a3bc6fcc
+ (9) d1e95e1ec1c398308f12c7b4fc8070f75ace08baf977deffac72fa25441ecb4d
+
+$ curl http://localhost:4200
+Kaya RPC Server%
+`
 
 ## License
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i "s/port: 4200/port: $PORT/g" /usr/src/app/config.js
+sed -i 's/remote: true/remote: $REMOTE/g' /usr/src/app/config.js
+
+exec node /usr/src/app/server.js --save $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sed -i "s/port: 4200/port: $PORT/g" /usr/src/app/config.js
-sed -i 's/remote: true/remote: $REMOTE/g' /usr/src/app/config.js
+sed -i "s/remote: true/remote: $REMOTE/g" /usr/src/app/config.js
 
 exec node /usr/src/app/server.js --save $@


### PR DESCRIPTION
## Description
An initial draft of a Dockerfile from which we could start to get to a proper docker image for Kaya RPC
Implementation of a dockerized Kaya RPC which could solve #31 

## Review Suggestion
- [x] initial draft
- [x] local development by building scilla-runner binary
- [x] local vs remote mode parameter
- [x] port as parameter
- [x] verbose vs normal mode parameter
- [ ] data volume for persistent data
- [x] publishing on docker hub
- [x] automated travis build
- [ ] dgoss serverspec tests
- [ ] update documentation

## Status
Initial draft

### Implementation
as for now I used my own account to demo the way travis could pick up changes automatically and push them to docker hub.
Once confirmed for merge this should obviously go under a Zilliqa docker account.

