### PR TITLE
Added npm package bin support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/Zilliqa/kaya"
   },
+  "bin": {
+    "kaya": "./server.js"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*
  This file is part of kaya.
   Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.


### PR DESCRIPTION
## Description
In order to use the kaya "binary" in a script we need it published to the node_modules/.bin folder.
Added that support and the environment tag to the server.js file.
 
## Status

### Implementation
- [X] **ready for review**
