### PR TITLE
Fix typo in GPL header

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /**
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
   
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/components/blockchain.js
+++ b/src/components/blockchain.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/components/wallet/wallet.js
+++ b/src/components/wallet/wallet.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 /*
 This file is part of kaya.
-Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
 kaya is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software

--- a/src/logic.js
+++ b/src/logic.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,6 @@
 /*
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
 
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,6 @@
 /**
  This file is part of kaya.
-  Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+  Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
   
   kaya is free software: you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
## Description
This PR fixes typo as the following: 
`Zilliqa Research Pvt. Ltd` -> `Zilliqa Research Pte. Ltd` 