### PR TITLE
Lowercase before running address

### DIFF
--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -158,6 +158,7 @@ module.exports = {
 
     let isCodeDeployment = payload.code && payload.toAddr === "0".repeat(40);
     contractAddr = (isCodeDeployment) ? contractAddr : payload.toAddr;
+    contractAddr = contractAddr.toLowerCase();
 
     const initPath = `${dir}${contractAddr}_init.json`;
     const codePath = `${dir}${contractAddr}_code.scilla`;


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
Running transitions fail on kaya because the ScillaRunner fetches the wrong file paths. The file paths need to be lowercased, as they are saved lower cased beforehand.

<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**
