### PR TITLE
Feature/multiple contract calls

### DIFF
--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -311,10 +311,10 @@ module.exports = {
     if (retMsg.message != null) {
       logVerbose(logLabel, `Next address: ${retMsg.message._recipient}`);
       responseData.nextAddress = retMsg.message._recipient;
+    } else {
+      // Contract deployment do not have the next address
+      responseData.nextAddress = '0'.repeat(40);
     }
-    // Contract deployment do not have the next address
-    responseData.nextAddress = '0'.repeat(40);
-
     return responseData;
   },
 };

--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -195,7 +195,7 @@ module.exports = {
    * @param { String } directory of the data files
    * @param { String } current block number
    * @param { String } gasLimit - gasLimit specified by the caller
-   * @returns { Object } consisting of `gasRemaining and nextAddress`
+   * @returns {{ gasRemaining, nextAddress, events, message }} - interpreter response
    */
   executeScillaRun: async (payload, newContractAddr, senderAddr, dir, currentBnum) => {
     // Get the blocknumber into a json file
@@ -306,11 +306,19 @@ module.exports = {
 
     const responseData = {};
     responseData.gasRemaining = retMsg.gas_remaining;
+    if (retMsg.events) {
+      responseData.events = retMsg.events.map(e => ({
+        ...e,
+        address: payload.toAddr,
+      }));
+    }
+    const message = retMsg.message;
+    if (message != null) {
+      responseData.message = message;
 
-    // Obtains the next address based on the message
-    if (retMsg.message != null) {
-      logVerbose(logLabel, `Next address: ${retMsg.message._recipient}`);
-      responseData.nextAddress = retMsg.message._recipient;
+      // Obtains the next address based on the message
+      logVerbose(logLabel, `Next address: ${message._recipient}`);
+      responseData.nextAddress = message._recipient;
     } else {
       // Contract deployment do not have the next address
       responseData.nextAddress = '0'.repeat(40);

--- a/test/multicontract.test.js
+++ b/test/multicontract.test.js
@@ -1,0 +1,131 @@
+const { readFileSync } = require('fs');
+const { BN, bytes, Long } = require('@zilliqa-js/util');
+const { Zilliqa } = require('@zilliqa-js/zilliqa');
+const KayaProvider = require('../src/provider');
+const { loadAccounts } = require('../src/components/wallet/wallet');
+
+const testWallet = {
+  address: '7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
+  privateKey: 'db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3',
+  publicKey: '03d8e6450e260f80983bcd4fadb6cbc132ae7feb552dda45f94b48c80b86c6c3be',
+  amount: '1000000000000000',
+  nonce: 0,
+};
+
+const getProvider = () => {
+  // sets up transaction history for accounts
+  loadAccounts({
+    [testWallet.address]: {
+      privateKey: testWallet.privateKey,
+      amount: testWallet.amount,
+      nonce: testWallet.nonce,
+    },
+  });
+  return new KayaProvider({ dataPath: 'data/' });
+};
+
+const CHAIN_ID = 111;
+const MSG_VERSION = 1;
+const version = bytes.pack(CHAIN_ID, MSG_VERSION);
+
+const getZilliqa = () => {
+  const zilliqa = new Zilliqa(null, getProvider());
+  zilliqa.wallet.addByPrivateKey(testWallet.privateKey);
+  zilliqa.wallet.setDefault(testWallet.address);
+  return zilliqa;
+};
+
+const defaultParams = {
+  version,
+  toAddr: `0x${'0'.repeat(40)}`,
+  amount: new BN(0),
+  gasPrice: new BN(1000000000),
+  gasLimit: Long.fromNumber(25000),
+};
+
+const deploymentParams = {
+  ...defaultParams,
+  gasLimit: Long.fromNumber(100000),
+};
+
+const transactionEventNames = tx => (
+  (tx.txParams.receipt.event_logs || []).map(l => l._eventname)
+);
+
+describe('Test Multicontract support', () => {
+  beforeAll(() => {
+    jest.setTimeout(55000);
+  });
+
+  test('Contract call chain should work', async () => {
+    const zilliqa = getZilliqa();
+    const [deployCTx, contractC] = await zilliqa.contracts
+      .new(
+        readFileSync(`${__dirname}/scilla/chain-call-balance-c.scilla`, 'utf8'),
+        [
+          { vname: '_scilla_version', type: 'Uint32', value: '0' },
+          { vname: '_creation_block', type: 'BNum', value: '0' },
+        ],
+      )
+      .deploy(deploymentParams);
+    expect(deployCTx.isConfirmed()).toBe(true);
+
+    const [deployBTx, contractB] = await zilliqa.contracts
+      .new(
+        readFileSync(`${__dirname}/scilla/chain-call-balance-b.scilla`, 'utf8'),
+        [
+          { vname: '_scilla_version', type: 'Uint32', value: '0' },
+          { vname: '_creation_block', type: 'BNum', value: '0' },
+        ],
+      )
+      .deploy(deploymentParams);
+    expect(deployBTx.isConfirmed()).toBe(true);
+
+    const [deployATx, contractA] = await zilliqa.contracts
+      .new(
+        readFileSync(`${__dirname}/scilla/chain-call-balance-a.scilla`, 'utf8'),
+        [
+          { vname: '_scilla_version', type: 'Uint32', value: '0' },
+          { vname: '_creation_block', type: 'BNum', value: '0' },
+        ],
+      )
+      .deploy(deploymentParams);
+    expect(deployATx.isConfirmed()).toBe(true);
+
+    const transitionCall = await contractA.call(
+      'acceptAAndTransferToBAndCallC',
+      [
+        { vname: 'addrB', type: 'ByStr20', value: `0x${contractB.address}` },
+        { vname: 'addrC', type: 'ByStr20', value: `0x${contractC.address}` },
+      ],
+      {
+        ...defaultParams,
+        amount: new BN(5),
+      },
+    );
+    expect(transitionCall.isConfirmed()).toBe(true);
+    expect(transactionEventNames(transitionCall))
+      .toEqual(['A', 'B', 'C']);
+    const [walletBalance, contractAState, contractBState, contractCState] = await (
+      Promise.all([
+        zilliqa.blockchain.getBalance(testWallet.address),
+        contractA.getState(),
+        contractB.getState(),
+        contractC.getState(),
+      ])
+    );
+    expect(walletBalance.result.nonce).toBe(4);
+    expect(contractAState).toEqual([
+      { vname: '_balance', type: 'Uint128', value: '0' },
+      { vname: 'last_amount', type: 'Uint128', value: '5' },
+    ]);
+    expect(contractBState).toEqual([
+      { vname: '_balance', type: 'Uint128', value: '0' },
+      { vname: 'last_amount', type: 'Uint128', value: '5' },
+    ]);
+    expect(contractCState).toEqual([
+      { vname: '_balance', type: 'Uint128', value: '5' },
+      { vname: 'last_amount', type: 'Uint128', value: '5' },
+    ]);
+  });
+});

--- a/test/scilla/chain-call-balance-a.scilla
+++ b/test/scilla/chain-call-balance-a.scilla
@@ -1,0 +1,36 @@
+scilla_version 0
+
+library Test
+
+let one_msg =
+  fun (msg : Message) =>
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+contract Test
+()
+
+field last_amount: Uint128 = Uint128 0
+
+(* Call contrB, passing contrC to it. Also pass on _amount. Emit event. *)
+transition acceptAAndTransferToBAndCallC (addrB : ByStr20, addrC : ByStr20)
+  accept;
+
+  last_amount := _amount;
+
+  e = {_eventname: "A"};
+  event e;
+
+  msg = { _tag : "acceptBAndTransferToC"; _amount : _amount; _recipient : addrB; addrC : addrC };
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition simplyAccept ()
+  accept;
+
+  last_amount := _amount;
+
+  e = {_eventname: "B"};
+  event e
+end

--- a/test/scilla/chain-call-balance-b.scilla
+++ b/test/scilla/chain-call-balance-b.scilla
@@ -1,0 +1,36 @@
+scilla_version 0
+
+library Test
+
+let one_msg =
+  fun (msg : Message) =>
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+contract Test
+()
+
+field last_amount: Uint128 = Uint128 0
+
+(* Call contrC. Also pass on _amount. Emit event. *)
+transition acceptBAndTransferToC (addrC : ByStr20)
+  accept;
+
+  last_amount := _amount;
+
+  e = {_eventname: "B"};
+  event e;
+
+  msg = { _tag : "simplyAccept"; _amount : _amount; _recipient : addrC };
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition simplyAccept ()
+  accept;
+
+  last_amount := _amount;
+
+  e = {_eventname: "B"};
+  event e
+end

--- a/test/scilla/chain-call-balance-c.scilla
+++ b/test/scilla/chain-call-balance-c.scilla
@@ -1,0 +1,30 @@
+scilla_version 0
+
+library Test
+
+let one_msg =
+  fun (msg : Message) =>
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+contract Test
+()
+
+field last_amount: Uint128 = Uint128 0
+
+(* Do not accept _amount. Emit event. *)
+transition noAcceptC ()
+  last_amount := _amount;
+
+  e = {_eventname: "C"};
+  event e
+end
+
+transition simplyAccept ()
+  accept;
+
+  last_amount := _amount;
+
+  e = {_eventname: "C"};
+  event e
+end

--- a/test/scripts/testblockchain.js
+++ b/test/scripts/testblockchain.js
@@ -13,80 +13,82 @@ zilliqa.wallet.addByPrivateKey(
   'db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3',
 );
 
-async function testBlockchain() {
-  try {
-    // Send a transaction to the network
-    const tx = await zilliqa.blockchain.createTransaction(
-      zilliqa.transactions.new({
-        version: VERSION,
-        toAddr: 'd90f2e538ce0df89c8273cad3b63ec44a3c4ed82',
-        amount: new BN(888),
-        // gasPrice must be >= minGasPrice
-        gasPrice: new BN('1_000_000_000'),
-        // can be `number` if size is <= 2^53 (i.e., window.MAX_SAFE_INTEGER)
-        gasLimit: Long.fromNumber(10),
-      }),
-    );
-    console.log(tx);
+console.log(zilliqa.wallet.accounts)
 
-    console.log('Deploying a contract now');
-    // Deploy a contract
-    const code = fs.readFileSync('HelloWorld.scilla', 'utf-8');
-    const init = [
-      {
-        vname: '_scilla_version',
-        type: 'Uint32',
-        value: '0',
-      },
-      {
-        vname: 'owner',
-        type: 'ByStr20',
-        // NOTE: all byte strings passed to Scilla contracts _must_ be
-        // prefixed with 0x. Failure to do so will result in the network
-        // rejecting the transaction while consuming gas!
-        value: '0x7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
-      },
-      // Necessary for local Kaya testing
-      {
-        vname: '_creation_block',
-        type: 'BNum',
-        value: '100',
-      },
-    ];
-
-    // instance of class Contract
-    const contract = zilliqa.contracts.new(code, init);
-
-    const [deployTx, hello] = await contract.deploy({
-      version: VERSION,
-      gasPrice: new BN('1_000_000_000'),
-      gasLimit: Long.fromNumber(5000),
-    });
-
-    // Introspect the state of the underlying transaction
-    console.log('Deployment Transaction ID: ', deployTx.id);
-    console.log('Deployment Transaction Receipt: ', deployTx.txParams.receipt);
-
-    const callTx = await hello.call('setHello', [
-      {
-        vname: 'msg',
-        type: 'String',
-        value: 'Hello World',
-      }],
-    {
-      version: VERSION,
-      amount: new BN(0),
-      gasPrice: new BN('1_000_000_000'),
-      gasLimit: Long.fromNumber(5000),
-    });
-    const { receipt } = callTx.txParams;
-    console.log(receipt);
-    const state = await hello.getState();
-    console.log(state);
-  } catch (err) {
-    console.log('Blockchain Error');
-    console.log(err);
-  }
-}
-
-testBlockchain();
+// async function testBlockchain() {
+//   try {
+//     // Send a transaction to the network
+//     const tx = await zilliqa.blockchain.createTransaction(
+//       zilliqa.transactions.new({
+//         version: VERSION,
+//         toAddr: 'd90f2e538ce0df89c8273cad3b63ec44a3c4ed82',
+//         amount: new BN(888),
+//         // gasPrice must be >= minGasPrice
+//         gasPrice: new BN('1_000_000_000'),
+//         // can be `number` if size is <= 2^53 (i.e., window.MAX_SAFE_INTEGER)
+//         gasLimit: Long.fromNumber(10),
+//       }),
+//     );
+//     console.log(tx);
+//
+//     console.log('Deploying a contract now');
+//     // Deploy a contract
+//     const code = fs.readFileSync('HelloWorld.scilla', 'utf-8');
+//     const init = [
+//       {
+//         vname: '_scilla_version',
+//         type: 'Uint32',
+//         value: '0',
+//       },
+//       {
+//         vname: 'owner',
+//         type: 'ByStr20',
+//         // NOTE: all byte strings passed to Scilla contracts _must_ be
+//         // prefixed with 0x. Failure to do so will result in the network
+//         // rejecting the transaction while consuming gas!
+//         value: '0x7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
+//       },
+//       // Necessary for local Kaya testing
+//       {
+//         vname: '_creation_block',
+//         type: 'BNum',
+//         value: '100',
+//       },
+//     ];
+//
+//     // instance of class Contract
+//     const contract = zilliqa.contracts.new(code, init);
+//
+//     const [deployTx, hello] = await contract.deploy({
+//       version: VERSION,
+//       gasPrice: new BN('1_000_000_000'),
+//       gasLimit: Long.fromNumber(5000),
+//     });
+//
+//     // Introspect the state of the underlying transaction
+//     console.log('Deployment Transaction ID: ', deployTx.id);
+//     console.log('Deployment Transaction Receipt: ', deployTx.txParams.receipt);
+//
+//     const callTx = await hello.call('setHello', [
+//       {
+//         vname: 'msg',
+//         type: 'String',
+//         value: 'Hello World',
+//       }],
+//     {
+//       version: VERSION,
+//       amount: new BN(0),
+//       gasPrice: new BN('1_000_000_000'),
+//       gasLimit: Long.fromNumber(5000),
+//     });
+//     const { receipt } = callTx.txParams;
+//     console.log(receipt);
+//     const state = await hello.getState();
+//     console.log(state);
+//   } catch (err) {
+//     console.log('Blockchain Error');
+//     console.log(err);
+//   }
+// }
+//
+// testBlockchain();


### PR DESCRIPTION
## Description
The goal of this PR is adding support for Scilla transitions that send messages to other transitions. The feature is called Multiple contracts call, i.e. when one smart contract transition calls the other smart contract transition.
Previously all messages sent by transitions were ignored. This was achieved by hardcoding`nextAddress` to 0. This PR allows different addresses for `nextAddress`.
Also added event_logs support from Scilla.

## Review Suggestion
@edisonljh please review.

## Status
Ready to be reviewed

### Implementation
- [+] **ready for review**
