### PR TITLE
GetNumTxBlocks added, explicit block confirmation added via new RPC call

### DIFF
--- a/src/components/blockchain.js
+++ b/src/components/blockchain.js
@@ -21,11 +21,13 @@ let bnum = config.blockchain.blockStart;
 
 function addBnum() {
   bnum += 1;
+  return bnum;
 }
 
 // blockinterval is duration for each block number increment
-setInterval(addBnum, config.blockchain.blockInterval);
+if (config.blockchain.blockInterval > 0) setInterval(addBnum, config.blockchain.blockInterval);
 
 module.exports = {
   getBlockNum: () => bnum,
+  addBnum,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -31,7 +31,7 @@ module.exports = {
   // blockchain specific configuration
   blockchain: {
     // sets timer for the block confirmation
-    blockInterval: 10000, // 10000 : 10 seconds for one block
+    blockInterval: 0, // automatic block confirmation time in ms, 0 disables automatic confirmation
     blockStart: 0,
     minimumGasPrice: new BN('1000000000'),
     transferGasCost: 1, // Amount of gas consumed for each transfer

--- a/src/provider.js
+++ b/src/provider.js
@@ -3,6 +3,7 @@ const logic = require('./logic');
 const wallet = require('./components/wallet/wallet');
 const config = require('./config');
 const { RPCError } = require('./components/CustomErrors');
+const { addBnum, getBlockNum } = require('./components/blockchain');
 
 const errorCodes = zCore.RPCErrorCode;
 
@@ -79,6 +80,10 @@ class Provider {
         return logic.processGetContractAddressByTransactionID(params);
       case 'GetMinimumGasPrice':
         return config.blockchain.minimumGasPrice.toString();
+      case 'KayaMine':
+        return addBnum();
+      case 'GetNumTxBlocks':
+        return getBlockNum();
       default:
         throw new RPCError(
           'METHOD_NOT_FOUND: The method being requested is not available on this server',

--- a/test/mining.test.js
+++ b/test/mining.test.js
@@ -1,0 +1,99 @@
+const { readFileSync } = require('fs');
+const { BN, bytes, Long } = require('@zilliqa-js/util');
+const { Zilliqa } = require('@zilliqa-js/zilliqa');
+const KayaProvider = require('../src/provider');
+const { loadAccounts } = require('../src/components/wallet/wallet');
+
+const testWallet = {
+  address: '7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
+  privateKey: 'db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3',
+  publicKey: '03d8e6450e260f80983bcd4fadb6cbc132ae7feb552dda45f94b48c80b86c6c3be',
+  amount: '1000000000000000',
+  nonce: 0,
+};
+
+const getProvider = () => {
+  // sets up transaction history for accounts
+  loadAccounts({
+    [testWallet.address]: {
+      privateKey: testWallet.privateKey,
+      amount: testWallet.amount,
+      nonce: testWallet.nonce,
+    },
+  });
+  return new KayaProvider({ dataPath: 'data/' });
+};
+
+const CHAIN_ID = 111;
+const MSG_VERSION = 1;
+const version = bytes.pack(CHAIN_ID, MSG_VERSION);
+
+const getZilliqa = () => {
+  const zilliqa = new Zilliqa(null, getProvider());
+  zilliqa.wallet.addByPrivateKey(testWallet.privateKey);
+  zilliqa.wallet.setDefault(testWallet.address);
+  return zilliqa;
+};
+
+const defaultParams = {
+  version,
+  toAddr: `0x${'0'.repeat(40)}`,
+  amount: new BN(0),
+  gasPrice: new BN(1000000000),
+  gasLimit: Long.fromNumber(25000),
+};
+
+const deploymentParams = {
+  ...defaultParams,
+  gasLimit: Long.fromNumber(100000),
+};
+
+const transactionEventNames = tx => (
+  (tx.txParams.receipt.event_logs || []).map(l => l._eventname)
+);
+
+describe('Test Mining support', () => {
+  beforeAll(() => {
+    jest.setTimeout(20000);
+  });
+
+  test('Block number should increase', async () => {
+    const zilliqa = getZilliqa();
+    const blockNumber0 = await zilliqa.blockchain.getNumTxBlocks();
+    expect(blockNumber0.result).toBe(0);
+    await zilliqa.provider.send('KayaMine');
+    const blockNumber1 = await zilliqa.blockchain.getNumTxBlocks();
+    expect(blockNumber1.result).toBe(1);
+    await zilliqa.provider.send('KayaMine');
+    const blockNumber2 = await zilliqa.blockchain.getNumTxBlocks();
+    expect(blockNumber2.result).toBe(2);
+  });
+
+  test('Scilla interpreter should get different block numbers', async () => {
+    const zilliqa = getZilliqa();
+    const [deployContract, contract] = await zilliqa.contracts
+      .new(
+        readFileSync(`${__dirname}/scilla/mining.scilla`, 'utf8'),
+        [
+          { vname: '_scilla_version', type: 'Uint32', value: '0' },
+          { vname: '_creation_block', type: 'BNum', value: '0' },
+        ],
+      )
+      .deploy(deploymentParams);
+    expect(deployContract.isConfirmed()).toBe(true);
+
+    const startTimerCall = await contract.call('startTimer', [], defaultParams);
+    expect(startTimerCall.isConfirmed()).toBe(true);
+
+    const checkCallBefore = await contract.call('checkTimer', [], defaultParams);
+    expect(transactionEventNames(checkCallBefore)).toEqual(['pending']);
+
+    // mine 3 blocks
+    await zilliqa.provider.send('KayaMine');
+    await zilliqa.provider.send('KayaMine');
+    await zilliqa.provider.send('KayaMine');
+
+    const checkCallAfter = await contract.call('checkTimer', [], defaultParams);
+    expect(transactionEventNames(checkCallAfter)).toEqual(['success']);
+  });
+});

--- a/test/scilla/mining.scilla
+++ b/test/scilla/mining.scilla
@@ -1,0 +1,39 @@
+scilla_version 0
+
+import BoolUtils
+
+library MiningTest
+
+let success_block_count = Uint32 3
+
+(* Contract starts timer based on block number. *)
+contract MiningTest
+()
+
+field timer_start: BNum = BNum 0
+
+transition startTimer ()
+  accept;
+  blk <- & BLOCKNUMBER;
+  timer_start := blk
+end
+
+(* Emit "success" if timer is complete. Emit "pending" if not. *)
+transition checkTimer ()
+  accept;
+  blk <- & BLOCKNUMBER;
+  start_blk <- timer_start;
+  success_blk = builtin badd start_blk success_block_count;
+  success_is_current = builtin eq success_blk blk;
+  success_is_passed = builtin blt success_blk blk;
+
+  is_success = orb success_is_current success_is_passed;
+  match is_success with
+  | False =>
+    e = {_eventname: "pending"};
+    event e
+  | True =>
+    e = {_eventname: "success"};
+    event e
+  end
+end


### PR DESCRIPTION
## Description
This PR:

- Adds support for "GetNumTxBlocks" RPC call;
- Adds option to disable automatic background block confirmation. 
- Adds explicit control over block confirmation via new "KayaMine" RPC call (specific for Kaya)

Reasoning:
Some contracts are using `blk <- & BLOCKNUMBER;` scilla construction to check current block in Scilla transitions. This PR allows explicitly invoke block confirmation for tests.

Tests added. Fetching block numbers both in Zilliqa JS client and in Scilla code.

## Review Suggestion
@edisonljh please review.

## Status
Blocked by https://github.com/Zilliqa/kaya/pull/95 (event_logs support is needed for tests).
Ready to be reviewed

### Implementation
- [+] **ready for review**
