### PR TITLE
fix create transaction payload

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -162,7 +162,9 @@ module.exports = {
     const dataElement = data[0];
     const payload = {
       ...dataElement,
-      gasLimit: dataElement.gasLimit.toString(),
+      amount: dataElement.amount.toString(), // BN - toJSON returns hex string
+      gasLimit: dataElement.gasLimit.toString(), // Long - toJSON is not defined
+      gasPrice: dataElement.gasPrice.toString(), // BN - toJSON returns hex string
     };
     const bnAmount = new BN(payload.amount);
     const bnGasLimit = new BN(payload.gasLimit);


### PR DESCRIPTION
## Description
`JSON.stringify` doesn't work correctly for BN and Long.
BN ([bn.js](https://github.com/indutny/bn.js/)) has [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) method but is makes all numbers hex instead of decimals.
Long ([long](https://github.com/dcodeIO/long.js#readme)) has no [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) method, so serialization doesn't work.
amount is BN
gasPrice is BN
gasLimit is Long

## Review Suggestion
@edisonljh please review.

## Status
Ready for review

### Implementation
- [+] **ready for review**
