### PR TITLE
Remove development junk

### DIFF
--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -156,7 +156,6 @@ const runLocalInterpreterAsync = async (cmdOptions, outputPath) => {
   }
 
   const result = await execFileAsync(SCILLA_BIN_PATH, cmdOptions);
-  console.log(result);
 
   if (result.stderr !== '') {
     console.log(`Interpreter error: ${result.stderr}`);


### PR DESCRIPTION
## Description

This causes too much uninformative noise in console:

```
  console.log node_modules/kaya-cli/src/components/scilla/scilla.js:159
    { stdout: '', stderr: '' }

  console.log node_modules/kaya-cli/src/components/scilla/scilla.js:159
    { stdout: '', stderr: '' }

  console.log node_modules/kaya-cli/src/components/scilla/scilla.js:159
    { stdout: '', stderr: '' }
```

[+] **ready for review**

cc @edisonljh 