### PR TITLE
Fix transaction amount transfer when toAddr has 0x prefix

### DIFF
--- a/src/components/wallet/wallet.js
+++ b/src/components/wallet/wallet.js
@@ -200,6 +200,7 @@ module.exports = {
     if (!zUtils.validation.isAddress(address)) {
       throw new RPCError('Address size not appropriate', errorCodes.RPC_INVALID_ADDRESS_OR_KEY, null);
     }
+    address = address.replace('0x', '');
     if (!wallets[address]) {
       // initialize new wallet account
       logVerbose(logLabel, `Creating new wallet account for ${address}`);


### PR DESCRIPTION
## Description

According to the api docs `toAddr` can be specified with `0x` prefix:
https://apidocs.zilliqa.com/#createtransaction
In this case, transaction `amount` are not transfered properly.

cc @edisonljh 

Test is not so easy to do because zilliqa js library automatically strips `0x`.

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
[*] **ready for review**
