### PR TITLE
Set _creation_block automatically in Kaya

### DIFF
--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -259,13 +259,13 @@ module.exports = {
         value: `0x${contractAddr}`,
       };
 
-      // const thisCreationBlock = {
-      //   vname: '_creation_block',
-      //   type: 'BNum',
-      //   value: `${currentBnum}`,
-      // };
+      const thisCreationBlock = {
+        vname: '_creation_block',
+        type: 'BNum',
+        value: `${currentBnum}`,
+      };
 
-      const deploymentPayload = [...acceptedPayload, thisAddr];
+      const deploymentPayload = [...acceptedPayload, thisAddr, thisCreationBlock];
       const initParams = JSON.stringify(deploymentPayload);
       await writeKayaFile(initPath, initParams);
 

--- a/test/init.json
+++ b/test/init.json
@@ -1,12 +1,7 @@
 [
     {
         "vname" : "owner",
-        "type" : "Address", 
+        "type" : "Address",
         "value" : "0x1234567890123456789012345678901234567890"
-    },
-    {
-        "vname" : "_creation_block",
-        "type" : "BNum",
-        "value" : "100"
     }
 ]

--- a/test/mining.test.js
+++ b/test/mining.test.js
@@ -79,7 +79,6 @@ describe('Test Mining support', () => {
         readFileSync(`${__dirname}/scilla/mining.scilla`, 'utf8'),
         [
           { vname: '_scilla_version', type: 'Uint32', value: '0' },
-          { vname: '_creation_block', type: 'BNum', value: '0' },
         ],
       )
       .deploy(deploymentParams);

--- a/test/multicontract.test.js
+++ b/test/multicontract.test.js
@@ -67,7 +67,6 @@ describe('Test Multicontract support', () => {
         readFileSync(`${__dirname}/scilla/chain-call-balance-c.scilla`, 'utf8'),
         [
           { vname: '_scilla_version', type: 'Uint32', value: '0' },
-          { vname: '_creation_block', type: 'BNum', value: '0' },
         ],
       )
       .deploy(deploymentParams);
@@ -78,7 +77,6 @@ describe('Test Multicontract support', () => {
         readFileSync(`${__dirname}/scilla/chain-call-balance-b.scilla`, 'utf8'),
         [
           { vname: '_scilla_version', type: 'Uint32', value: '0' },
-          { vname: '_creation_block', type: 'BNum', value: '0' },
         ],
       )
       .deploy(deploymentParams);
@@ -89,7 +87,6 @@ describe('Test Multicontract support', () => {
         readFileSync(`${__dirname}/scilla/chain-call-balance-a.scilla`, 'utf8'),
         [
           { vname: '_scilla_version', type: 'Uint32', value: '0' },
-          { vname: '_creation_block', type: 'BNum', value: '0' },
         ],
       )
       .deploy(deploymentParams);

--- a/test/scripts/testblockchain.js
+++ b/test/scripts/testblockchain.js
@@ -46,12 +46,6 @@ async function testBlockchain() {
         // rejecting the transaction while consuming gas!
         value: '0x7bb3b0e8a59f3f61d9bff038f4aeb42cae2ecce8',
       },
-      // Necessary for local Kaya testing
-      {
-        vname: '_creation_block',
-        type: 'BNum',
-        value: '100',
-      },
     ];
 
     // instance of class Contract


### PR DESCRIPTION
Currently kaya requires `_creation_block` to be specified in paramters during the RPC call.
That should not be the case and parameter should be set automatically instead.

cc @edisonljh 