### PR TITLE
Run checker with -gaslimit option

### DIFF
--- a/src/components/scilla/scilla.js
+++ b/src/components/scilla/scilla.js
@@ -303,7 +303,7 @@ module.exports = {
 
     let retMsg;
     if (!config.scilla.remote) {
-      const checkerCmdOpts = ['-libdir', config.constants.smart_contract.SCILLA_LIB, codePath];
+      const checkerCmdOpts = [...standardOpt, codePath];
       await runLocalCheckerAsync(checkerCmdOpts);
       // local scilla interpreter
       retMsg = await runLocalInterpreterAsync(cmdOpt, outputPath);


### PR DESCRIPTION
## Description
`scilla-checker` now requires `-gaslimit` as a mandatory option: https://github.com/Zilliqa/scilla/commit/c0da7e8b689be3ab4cae199bcfebfdb44e39e5b7

This PR updates `checkerCmdOpts` to include `standardOpt` array, so that `scilla-checker` runs with the same `gaslimit` specified.

## Status
- [x] **ready for review**

cc @edisonljh
