### PR TITLE
Use GetSmartContractState new format

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -432,12 +432,18 @@ module.exports = {
       throw new RPCError('Address does not exist', errorCodes.RPC_INVALID_ADDRESS_OR_KEY, null);
     }
 
-    const responseData = fs.readFileSync(filePath, 'utf-8');
+    let responseData = fs.readFileSync(filePath, 'utf-8');
     if (fileType === 'code') {
       return { code: responseData };
     }
-    // handles init and state json after parsing
-    return JSON.parse(responseData);
+    responseData = JSON.parse(responseData);
+
+    if (fileType === 'state') {
+      result = {};
+      responseData.forEach(field => result[field.vname] = field.value);
+      return result;
+    }
+    return responseData;
   },
 
   /**

--- a/test/multicontract.test.js
+++ b/test/multicontract.test.js
@@ -118,17 +118,8 @@ describe('Test Multicontract support', () => {
       ])
     );
     expect(walletBalance.result.nonce).toBe(4);
-    expect(contractAState).toEqual([
-      { vname: '_balance', type: 'Uint128', value: '0' },
-      { vname: 'last_amount', type: 'Uint128', value: '5' },
-    ]);
-    expect(contractBState).toEqual([
-      { vname: '_balance', type: 'Uint128', value: '0' },
-      { vname: 'last_amount', type: 'Uint128', value: '5' },
-    ]);
-    expect(contractCState).toEqual([
-      { vname: '_balance', type: 'Uint128', value: '5' },
-      { vname: 'last_amount', type: 'Uint128', value: '5' },
-    ]);
+    expect(contractAState).toEqual({_balance: '0', last_amount: '5'});
+    expect(contractBState).toEqual({_balance: '0', last_amount: '5'})
+    expect(contractCState).toEqual({_balance: '5', last_amount: '5'})
   });
 });


### PR DESCRIPTION
Zilliqa has changed the response format for this method from Array into Object a while ago.
Porting the change to kaya accordingly.

cc @edisonljh 