### PR TITLE
Add scilla version to stdlibs

### DIFF
--- a/src/components/scilla/stdlib/BoolUtils.scillib
+++ b/src/components/scilla/stdlib/BoolUtils.scillib
@@ -1,3 +1,4 @@
+scilla_version 0
 library BoolUtils
 
 let andb = 

--- a/src/components/scilla/stdlib/IntUtils.scillib
+++ b/src/components/scilla/stdlib/IntUtils.scillib
@@ -1,3 +1,4 @@
+scilla_version 0
 library IntUtils
 
 let int_neq =

--- a/src/components/scilla/stdlib/ListUtils.scillib
+++ b/src/components/scilla/stdlib/ListUtils.scillib
@@ -1,3 +1,4 @@
+scilla_version 0
 library ListUtils
 
 (* ('A -> 'B) -> List 'A -> List 'B *)

--- a/src/components/scilla/stdlib/NatUtils.scillib
+++ b/src/components/scilla/stdlib/NatUtils.scillib
@@ -1,3 +1,4 @@
+scilla_version 0
 library NatUtils
 
 (* Nat -> Option Nat *)

--- a/src/components/scilla/stdlib/PairUtils.scillib
+++ b/src/components/scilla/stdlib/PairUtils.scillib
@@ -1,3 +1,4 @@
+scilla_version 0
 library PairUtils
 
 let fst =


### PR DESCRIPTION
Scilla 0.5.1 has  breaking change that requires scilla version to be specified in libraries.

cc @edisonljh 