### PR TITLE
Deprecation Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 [![Build Status](https://travis-ci.com/Zilliqa/kaya.svg?branch=master)](https://travis-ci.com/Zilliqa/kaya)
 
 
+## Deprecation Notice
+
+This repository is deprecated. Please use [isolated server](https://github.com/Zilliqa/Zilliqa/blob/master/ISOLATED_SERVER_setup.md) for your local testing.
+
+## Introduction
+
 Kaya is Zilliqa's RPC server for testing and development. It is personal blockchain which makes developing application easier and faster. Kaya emulates the Zilliqa's blockchain behavior, and follows the expected server behavior as seen in the [`zilliqa-js`](https://github.com/Zilliqa/Zilliqa-JavaScript-Library).
 
 The goal of the project is to support all endpoints in Zilliqa Javascript API, making it easy for app developers to build Dapps on our platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4358,7 +4358,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4379,12 +4380,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4399,17 +4402,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4526,7 +4532,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4538,6 +4545,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4552,6 +4560,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4559,12 +4568,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4583,6 +4594,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4670,7 +4682,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4682,6 +4695,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4767,7 +4781,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4803,6 +4818,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4822,6 +4838,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4865,12 +4882,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4948,6 +4967,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4971,9 +4991,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5448,7 +5468,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5475,6 +5496,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -10534,9 +10556,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
           "dev": true,
           "optional": true
         },

--- a/src/logic.js
+++ b/src/logic.js
@@ -27,7 +27,7 @@ const scillaCtrl = require('./components/scilla/scilla');
 const walletCtrl = require('./components/wallet/wallet');
 const blockchain = require('./components/blockchain');
 const { InterpreterError, BalanceError, RPCError } = require('./components/CustomErrors');
-const { logVerbose, consolePrint } = require('./utilities');
+const { logVerbose, consolePrint, isDeployContract } = require('./utilities');
 const config = require('./config');
 
 const logLabel = ('LOGIC');
@@ -71,9 +71,9 @@ const confirmTransaction = (payload, transactionID, receiptInfo) => {
     gasPrice: payload.gasPrice,
     nonce: payload.nonce,
     receipt: receiptInfo,
-    senderPubKey: payload.pubKey,
-    signature: payload.signature,
-    toAddr: payload.toAddr,
+    senderPubKey: "0x".concat(payload.pubKey),
+    signature: "0x".concat(payload.signature),
+    toAddr: payload.toAddr.replace('0x', ''),
     version: payload.version,
   };
   transactions[transactionID] = txnDetails;
@@ -265,7 +265,8 @@ module.exports = {
           }
         };
 
-        const isDeployment = payload.code && payload.toAddr === '0'.repeat(40);
+        const isDeployment = payload.code && isDeployContract(payload.toAddr);
+        console.log(isDeployment);
         const deployedContractAddress = isDeployment ? computeContractAddr(senderAddress) : null;
         // Always increase nonce whenever the interpreter is run
         // Interpreter can throw an InterpreterError

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -177,4 +177,9 @@ module.exports = {
       module.exports.logVerbose(logLabel, `${__dirname}/${dataPath} created`);
     }
   },
+
+
+  isDeployContract: (toAddress) => {
+    return toAddress.replace('0x', '') === '0'.repeat(40)
+  }
 };


### PR DESCRIPTION
While Kaya-RPC was useful in the early days of Zilliqa when there was no way to quickly test the app, the utility of this tool diminishes over time. It has been challenging to keep up with the progress of the zilliqa blockchain and replicate the exact behavior of Zilliqa blockchain into a separate codebase. The lack of regular updates to Kaya meant that Kaya is always a few versions behind the zilliqa blockchain, and is therefore not ideal for the developer experience.

Since a few months ago, I've switched to use isolated server for testing, and it has been great. We use it a lot in Aqilliz for local testing, and I've already stopped maintaining Kaya-RPC since several months ago. This deprecation notice is late, but it should be there to let people know that we are not maintaining the codebase anymore. 

The core team has made available an [isolated server](https://github.com/Zilliqa/Zilliqa/blob/master/ISOLATED_SERVER_setup.md) that is ideal for running test servers locally. 


### Will there still be a need for a different version of test server? 

Isolated server has a higher memory footprint and CPU usage compared to Kaya -RPC. If someone is willing to commit to build a new Kaya-RPC and maintain it continuously over a long period of time, they could. 

If someone wants to build a new kaya-rpc, they should make from scratch. This Kaya-RPC started off as a test server internally, and over time, I've been applying patches and patches and never got to refactor any of the codebase. I'm not proud at all with how the code organisation is laid out. Will be good if someone remakes this from scratch. 

And please use a proper db instead of storing `json` files the next time.